### PR TITLE
unify Identity type across packages

### DIFF
--- a/internal/identity/identity.go
+++ b/internal/identity/identity.go
@@ -6,16 +6,16 @@ import "time"
 
 // Identity holds a complete generated persona.
 type Identity struct {
-	ID        string    // 8-char hex
-	FirstName string
-	LastName  string
-	Email     string    // <adjective><noun><4digits>@zburn.id
-	Phone     string    // US format: (555) XXX-XXXX
-	Street    string
-	City      string
-	State     string    // US state abbreviation
-	Zip       string
-	DOB       time.Time
-	Password  string
-	CreatedAt time.Time
+	ID        string    `json:"id"`
+	FirstName string    `json:"first_name"`
+	LastName  string    `json:"last_name"`
+	Email     string    `json:"email"`
+	Phone     string    `json:"phone"`
+	Street    string    `json:"street"`
+	City      string    `json:"city"`
+	State     string    `json:"state"`
+	Zip       string    `json:"zip"`
+	DOB       time.Time `json:"dob"`
+	Password  string    `json:"password"`
+	CreatedAt time.Time `json:"created_at"`
 }

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -6,10 +6,11 @@ import (
 	"time"
 
 	"github.com/zarlcorp/core/pkg/zfilesystem"
+	"github.com/zarlcorp/zburn/internal/identity"
 )
 
-func newTestIdentity(id string, createdAt time.Time) Identity {
-	return Identity{
+func newTestIdentity(id string, createdAt time.Time) identity.Identity {
+	return identity.Identity{
 		ID:        id,
 		FirstName: "Jane",
 		LastName:  "Doe",
@@ -205,7 +206,7 @@ func TestCloseErasesKey(t *testing.T) {
 func TestRoundTripPreservesAllFields(t *testing.T) {
 	s, _ := openTestStore(t)
 
-	want := Identity{
+	want := identity.Identity{
 		ID:        "full-fields",
 		FirstName: "Alice",
 		LastName:  "Smith",
@@ -274,7 +275,7 @@ func TestDataPersistsAcrossReopen(t *testing.T) {
 	assertIdentityEqual(t, want, got)
 }
 
-func assertIdentityEqual(t *testing.T, want, got Identity) {
+func assertIdentityEqual(t *testing.T, want, got identity.Identity) {
 	t.Helper()
 
 	checks := []struct {


### PR DESCRIPTION
## Summary
- Add JSON tags to identity.Identity
- Update store to import identity.Identity instead of duplicate type
- Remove store.Identity struct

Prerequisite for CLI (047) and TUI (048) specs.