### PR TITLE
047: CLI subcommands

### DIFF
--- a/cmd/zburn/main.go
+++ b/cmd/zburn/main.go
@@ -8,6 +8,7 @@ import (
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/zarlcorp/core/pkg/zapp"
+	"github.com/zarlcorp/zburn/internal/cli"
 	"github.com/zarlcorp/zburn/internal/tui"
 )
 
@@ -42,6 +43,18 @@ func runCLI(_ context.Context, cmd string) {
 	switch cmd {
 	case "version":
 		fmt.Printf("zburn %s\n", version)
+	case "email":
+		cli.CmdEmail()
+	case "identity":
+		cli.CmdIdentity(os.Args[2:])
+	case "list":
+		cli.CmdList(os.Args[2:])
+	case "forget":
+		if len(os.Args) < 3 {
+			fmt.Fprintln(os.Stderr, "usage: zburn forget <id>")
+			os.Exit(1)
+		}
+		cli.CmdForget(os.Args[2])
 	default:
 		fmt.Fprintf(os.Stderr, "zburn: unknown command %q\n", cmd)
 		os.Exit(1)

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/zarlcorp/core/pkg/zcrypto v0.2.0
 	github.com/zarlcorp/core/pkg/zfilesystem v0.2.0
 	github.com/zarlcorp/core/pkg/zstyle v0.1.0
+	golang.org/x/term v0.40.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -66,5 +66,7 @@ golang.org/x/sys v0.0.0-20210809222454-d867a43fc93e/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.41.0 h1:Ivj+2Cp/ylzLiEU89QhWblYnOE9zerudt9Ftecq2C6k=
 golang.org/x/sys v0.41.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=
+golang.org/x/term v0.40.0 h1:36e4zGLqU4yhjlmxEaagx2KuYbJq3EwY8K943ZsHcvg=
+golang.org/x/term v0.40.0/go.mod h1:w2P8uVp06p2iyKKuvXIm7N/y0UCRt3UfJTfZ7oOpglM=
 golang.org/x/text v0.34.0 h1:oL/Qq0Kdaqxa1KbNeMKwQq0reLCCaFtqu2eNuSeNHbk=
 golang.org/x/text v0.34.0/go.mod h1:homfLqTYRFyVYemLBFl5GgL/DWEiH5wcsQ5gSh1yziA=

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -1,0 +1,206 @@
+// Package cli implements zburn's command-line subcommands.
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"syscall"
+
+	"github.com/zarlcorp/core/pkg/zfilesystem"
+	"github.com/zarlcorp/zburn/internal/identity"
+	"github.com/zarlcorp/zburn/internal/store"
+	"golang.org/x/term"
+)
+
+// DataDir returns the default data directory for zburn.
+func DataDir() string {
+	if d := os.Getenv("XDG_DATA_HOME"); d != "" {
+		return d + "/zburn"
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ".zburn"
+	}
+	return home + "/.local/share/zburn"
+}
+
+// ReadPassword prompts for a password on stderr and reads it without echo.
+func ReadPassword(prompt string, w io.Writer) (string, error) {
+	fmt.Fprint(w, prompt)
+	b, err := term.ReadPassword(int(syscall.Stdin))
+	fmt.Fprintln(w)
+	if err != nil {
+		return "", fmt.Errorf("read password: %w", err)
+	}
+	return string(b), nil
+}
+
+// ReadNewPassword prompts for a new password with confirmation.
+func ReadNewPassword(w io.Writer) (string, error) {
+	pass, err := ReadPassword("master password: ", w)
+	if err != nil {
+		return "", err
+	}
+	confirm, err := ReadPassword("confirm password: ", w)
+	if err != nil {
+		return "", err
+	}
+	if pass != confirm {
+		return "", fmt.Errorf("passwords do not match")
+	}
+	return pass, nil
+}
+
+// IsFirstRun checks whether the store has been initialized.
+func IsFirstRun(dir string) bool {
+	_, err := os.Stat(dir + "/salt")
+	return err != nil
+}
+
+// OpenStore prompts for a password and opens the store.
+func OpenStore(dir string) (*store.Store, error) {
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return nil, fmt.Errorf("create data dir: %w", err)
+	}
+
+	var pass string
+	var err error
+	if IsFirstRun(dir) {
+		pass, err = ReadNewPassword(os.Stderr)
+	} else {
+		pass, err = ReadPassword("master password: ", os.Stderr)
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	fsys := zfilesystem.NewOSFileSystem(dir)
+	s, err := store.Open(fsys, pass)
+	if err != nil {
+		return nil, err
+	}
+	return s, nil
+}
+
+// CmdEmail generates and prints a random email.
+func CmdEmail() {
+	g := identity.New()
+	fmt.Println(g.Email())
+}
+
+// CmdIdentity generates and prints a complete identity.
+func CmdIdentity(args []string) {
+	asJSON := hasFlag(args, "--json")
+	save := hasFlag(args, "--save")
+
+	g := identity.New()
+	id := g.Generate()
+
+	if asJSON {
+		printJSON(id)
+	} else {
+		printIdentity(id)
+	}
+
+	if save {
+		dir := DataDir()
+		s, err := OpenStore(dir)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "zburn: %v\n", err)
+			os.Exit(1)
+		}
+		defer s.Close()
+
+		if err := s.Save(id); err != nil {
+			fmt.Fprintf(os.Stderr, "zburn: save: %v\n", err)
+			os.Exit(1)
+		}
+		fmt.Fprintln(os.Stderr, "saved")
+	}
+}
+
+// CmdList lists all saved identities.
+func CmdList(args []string) {
+	asJSON := hasFlag(args, "--json")
+
+	dir := DataDir()
+	s, err := OpenStore(dir)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "zburn: %v\n", err)
+		os.Exit(1)
+	}
+	defer s.Close()
+
+	ids, err := s.List()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "zburn: list: %v\n", err)
+		os.Exit(1)
+	}
+
+	if len(ids) == 0 {
+		fmt.Println("no saved identities")
+		return
+	}
+
+	if asJSON {
+		printJSON(ids)
+		return
+	}
+
+	for _, id := range ids {
+		fmt.Printf("  %-10s %-20s %-30s %s\n",
+			id.ID,
+			id.FirstName+" "+id.LastName,
+			id.Email,
+			id.CreatedAt.Format("2006-01-02"),
+		)
+	}
+}
+
+// CmdForget deletes a saved identity by ID.
+func CmdForget(id string) {
+	dir := DataDir()
+	s, err := OpenStore(dir)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "zburn: %v\n", err)
+		os.Exit(1)
+	}
+	defer s.Close()
+
+	if err := s.Delete(id); err != nil {
+		fmt.Fprintf(os.Stderr, "zburn: forget: %v\n", err)
+		os.Exit(1)
+	}
+	fmt.Printf("deleted %s\n", id)
+}
+
+func printIdentity(id identity.Identity) {
+	fmt.Printf("  id:       %s\n", id.ID)
+	fmt.Printf("  name:     %s %s\n", id.FirstName, id.LastName)
+	fmt.Printf("  email:    %s\n", id.Email)
+	fmt.Printf("  phone:    %s\n", id.Phone)
+	fmt.Printf("  address:  %s, %s, %s %s\n", id.Street, id.City, id.State, id.Zip)
+	fmt.Printf("  dob:      %s\n", id.DOB.Format("2006-01-02"))
+	fmt.Printf("  password: %s\n", id.Password)
+}
+
+func printJSON(v any) {
+	enc := json.NewEncoder(os.Stdout)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(v); err != nil {
+		fmt.Fprintf(os.Stderr, "zburn: encode json: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func hasFlag(args []string, flag string) bool {
+	for _, a := range args {
+		if strings.EqualFold(a, flag) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -1,0 +1,79 @@
+package cli
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestDataDir(t *testing.T) {
+	tests := []struct {
+		name string
+		xdg  string
+		want string
+	}{
+		{
+			name: "xdg set",
+			xdg:  "/custom/data",
+			want: "/custom/data/zburn",
+		},
+		{
+			name: "xdg empty falls back to home",
+			xdg:  "",
+			want: "/.local/share/zburn",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			os.Setenv("XDG_DATA_HOME", tt.xdg)
+			defer os.Unsetenv("XDG_DATA_HOME")
+
+			got := DataDir()
+			if tt.xdg != "" {
+				if got != tt.want {
+					t.Errorf("DataDir() = %s, want %s", got, tt.want)
+				}
+			} else {
+				if !strings.HasSuffix(got, tt.want) {
+					t.Errorf("DataDir() = %s, want suffix %s", got, tt.want)
+				}
+			}
+		})
+	}
+}
+
+func TestHasFlag(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+		flag string
+		want bool
+	}{
+		{"present", []string{"--json", "--save"}, "--json", true},
+		{"absent", []string{"--save"}, "--json", false},
+		{"empty", nil, "--json", false},
+		{"case insensitive", []string{"--JSON"}, "--json", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := hasFlag(tt.args, tt.flag)
+			if got != tt.want {
+				t.Errorf("hasFlag(%v, %s) = %v, want %v", tt.args, tt.flag, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsFirstRun(t *testing.T) {
+	dir := t.TempDir()
+	if !IsFirstRun(dir) {
+		t.Error("expected first run for empty dir")
+	}
+
+	os.WriteFile(dir+"/salt", []byte("test"), 0o600)
+	if IsFirstRun(dir) {
+		t.Error("expected not first run after salt exists")
+	}
+}


### PR DESCRIPTION
Closes #6

Add `email`, `identity`, `list`, `forget` subcommands with --json and --save flags.

Spec: zarlcorp/core .manager/specs/047-cli-subcommands.md