### PR TITLE
052: add release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,10 @@
+name: Release
+on:
+  push:
+    tags: ["v*"]
+
+jobs:
+  release:
+    uses: zarlcorp/.github/.github/workflows/go-release.yml@main
+    with:
+      binary-name: zburn


### PR DESCRIPTION
Part of #14

Adds .github/workflows/release.yml that calls the shared go-release workflow on tag push.

Spec: zarlcorp/core/.manager/specs/052-first-release.md