### PR TITLE
052: fix release workflow permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,9 @@ on:
   push:
     tags: ["v*"]
 
+permissions:
+  contents: write
+
 jobs:
   release:
     uses: zarlcorp/.github/.github/workflows/go-release.yml@main


### PR DESCRIPTION
Part of #14

Add permissions: contents: write to the caller workflow so the reusable workflow can create GitHub Releases.