### PR TITLE
055: add GitHub Pages — landing + docs

### DIFF
--- a/docs/docs.html
+++ b/docs/docs.html
@@ -1,0 +1,112 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>zburn — Documentation</title>
+  <meta name="description" content="Usage documentation for zburn: disposable identity generator with interactive TUI and scriptable CLI.">
+  <link rel="stylesheet" href="https://zarlcorp.github.io/shared.css">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="container">
+
+    <nav class="nav">
+      <a href="https://zarlcorp.github.io" class="nav-brand">zarlcorp</a>
+      <a href="index.html">Home</a>
+      <a href="https://github.com/zarlcorp/zburn">GitHub</a>
+    </nav>
+
+    <div class="doc-content">
+
+      <h1>zburn docs</h1>
+
+      <h2>Interactive TUI</h2>
+
+      <p>Run <code>zburn</code> with no arguments to launch the interactive terminal interface.</p>
+
+      <pre><code>$ zburn</code></pre>
+
+      <p>The TUI walks you through:</p>
+      <ol>
+        <li><strong>Master password</strong> &mdash; create on first run, then enter to unlock</li>
+        <li><strong>Menu</strong> &mdash; generate, browse saved identities, or quick-copy a burner email</li>
+        <li><strong>Generate</strong> &mdash; create a new disposable identity and optionally save it</li>
+        <li><strong>Browse</strong> &mdash; list and manage all saved identities</li>
+        <li><strong>Detail</strong> &mdash; inspect individual fields and copy them to the clipboard</li>
+      </ol>
+
+      <h2>CLI commands</h2>
+
+      <h3>Generate a burner email</h3>
+
+      <pre><code>$ zburn email</code></pre>
+
+      <p>Prints a random burner email to stdout.</p>
+
+      <h3>Generate a complete identity</h3>
+
+      <pre><code>$ zburn identity</code></pre>
+
+      <p>Outputs a full disposable identity: name, email, address, phone, password.</p>
+
+      <table>
+        <thead>
+          <tr><th>Flag</th><th>Description</th></tr>
+        </thead>
+        <tbody>
+          <tr><td><code>--json</code></td><td>Output as JSON instead of formatted text</td></tr>
+          <tr><td><code>--save</code></td><td>Encrypt and save to the store (prompts for master password)</td></tr>
+        </tbody>
+      </table>
+
+      <p>Example &mdash; generate, format as JSON, and save:</p>
+
+      <pre><code>$ zburn identity --json --save</code></pre>
+
+      <h3>List saved identities</h3>
+
+      <pre><code>$ zburn list</code></pre>
+
+      <table>
+        <thead>
+          <tr><th>Flag</th><th>Description</th></tr>
+        </thead>
+        <tbody>
+          <tr><td><code>--json</code></td><td>Output as JSON instead of formatted text</td></tr>
+        </tbody>
+      </table>
+
+      <h3>Delete a saved identity</h3>
+
+      <pre><code>$ zburn forget &lt;id&gt;</code></pre>
+
+      <p>Permanently removes a saved identity by its ID.</p>
+
+      <h3>Print version</h3>
+
+      <pre><code>$ zburn version</code></pre>
+
+      <h2>Data storage</h2>
+
+      <p>Saved identities are encrypted at rest. zburn uses <strong>AES-256-GCM</strong> for encryption with a master key derived from your password via <strong>Argon2id</strong> key derivation.</p>
+
+      <p>Data is stored locally in:</p>
+
+      <pre><code>~/.local/share/zburn/</code></pre>
+
+      <p>No data ever leaves your machine. There are no accounts, no servers, no sync. Your identities live on your disk, encrypted with a key only you know.</p>
+
+      <hr>
+
+      <p><a href="index.html">&larr; Back to zburn</a> &middot; <a href="https://zarlcorp.github.io">zarlcorp.github.io</a></p>
+
+    </div>
+
+    <footer class="footer">
+      <p>Open source. MIT licensed.</p>
+    </footer>
+
+  </div>
+</body>
+</html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>zburn — Disposable identities.</title>
+  <meta name="description" content="Disposable identities — never give a service your real information again. Generate burner emails, names, addresses, passwords. Encrypted local storage.">
+  <link rel="stylesheet" href="https://zarlcorp.github.io/shared.css">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="landing">
+    <div class="container">
+
+      <nav class="nav">
+        <a href="https://zarlcorp.github.io" class="nav-brand">zarlcorp</a>
+        <a href="docs.html">Docs</a>
+        <a href="https://github.com/zarlcorp/zburn">GitHub</a>
+      </nav>
+
+      <header class="hero">
+        <div class="logo">zburn</div>
+        <div class="tagline">Disposable identities &mdash; never give a service your real information again.</div>
+      </header>
+
+      <section class="features">
+        <ul class="feature-list">
+          <li>Generate burner emails, names, addresses, passwords</li>
+          <li>Encrypted local storage with AES-256-GCM</li>
+          <li>Interactive TUI + scriptable CLI</li>
+          <li>Copy to clipboard instantly</li>
+        </ul>
+      </section>
+
+      <section class="install">
+        <div class="install-os-aware">
+          <div class="install-macos">
+            <div class="install-cmd"><span class="prompt">$ </span>brew install zarlcorp/tap/zburn</div>
+          </div>
+          <div class="install-linux">
+            <div class="install-cmd"><span class="prompt">$ </span>curl -sL https://github.com/zarlcorp/zburn/releases/latest/download/zburn_linux_amd64 -o zburn && chmod +x zburn</div>
+          </div>
+        </div>
+        <script src="https://zarlcorp.github.io/install.js"></script>
+      </section>
+
+      <footer class="footer">
+        <p>Open source. MIT licensed.</p>
+        <p><a href="https://zarlcorp.github.io">zarlcorp.github.io</a></p>
+      </footer>
+
+    </div>
+  </div>
+</body>
+</html>

--- a/docs/style.css
+++ b/docs/style.css
@@ -1,0 +1,46 @@
+/* zburn site — page-specific overrides */
+/* shared design system lives at zarlcorp.github.io/shared.css */
+
+/* --- landing page: single viewport --- */
+
+.landing {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  min-height: 100vh;
+  max-height: 100vh;
+  overflow: hidden;
+}
+
+.landing .hero {
+  padding: 2rem 0 1.5rem;
+}
+
+.landing .tagline {
+  font-size: 1.1rem;
+}
+
+/* features */
+
+.features {
+  text-align: center;
+  padding: 0.75rem 0;
+}
+
+.features .feature-list {
+  display: inline-block;
+  text-align: left;
+}
+
+/* install */
+
+.landing .install {
+  padding: 1.5rem 0;
+  text-align: center;
+}
+
+/* footer */
+
+.landing .footer {
+  padding: 1rem 0 1.5rem;
+}


### PR DESCRIPTION
Closes #18

Adds docs/index.html (single-viewport landing page) and docs/docs.html (CLI and TUI documentation). Uses shared CSS design system from zarlcorp.github.io.

Spec: zarlcorp/core/.manager/specs/055-zburn-pages.md