### PR TITLE
add GitHub Pages link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ make run
 
 ## Learn More
 
+- [Website](https://zarlcorp.github.io/zburn) — Documentation and install instructions
 - [zarlcorp/core](https://github.com/zarlcorp/core) — shared Go packages
 - [MANIFESTO.md](https://github.com/zarlcorp/core/blob/main/MANIFESTO.md) — philosophy and architecture
 


### PR DESCRIPTION
Adds a link to https://zarlcorp.github.io/zburn in the Learn More section.