### PR TITLE
068: fix nav bar consistency

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -13,7 +13,7 @@
   <nav class="bar">
     <div class="container">
       <a href="https://zarlcorp.github.io" class="nav-brand">zarlcorp</a>
-      <a href="docs.html">docs</a>
+      <a href="docs.html">documentation</a>
       <a href="https://github.com/zarlcorp/zburn">github</a>
     </div>
   </nav>


### PR DESCRIPTION
Ref #25

Nav bar on landing and docs pages now matches org site pattern: zarlcorp | documentation | github (all lowercase).