### PR TITLE
071: remove layout overrides, use shared.css base

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -18,7 +18,7 @@
     </div>
   </nav>
 
-  <div class="landing">
+  <section class="landing">
     <div class="container">
 
       <header class="hero">
@@ -66,7 +66,7 @@
       </footer>
 
     </div>
-  </div>
+  </section>
 
 </body>
 </html>

--- a/docs/style.css
+++ b/docs/style.css
@@ -4,36 +4,10 @@
 /* tool accent: peach */
 :root { --accent: var(--peach); }
 
-/* --- landing page: single viewport --- */
-
-.landing {
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  min-height: 100vh;
-  max-height: 100vh;
-  overflow: hidden;
-}
-
-.landing .hero {
-  padding: 2rem 0 1.25rem;
-}
-
-.landing .tagline {
-  font-size: 1rem;
-}
-
 /* features window */
 
 .landing .features {
   padding: 0.75rem 0;
-}
-
-/* install */
-
-.landing .install {
-  padding: 1.25rem 0;
-  text-align: center;
 }
 
 /* links row */
@@ -55,12 +29,6 @@
 .landing-links .sep {
   color: var(--surface2);
   margin: 0 0.5rem;
-}
-
-/* footer */
-
-.landing .footer {
-  padding: 1rem 0 1.5rem;
 }
 
 /* --- docs page --- */


### PR DESCRIPTION
Closes #29

- removed .landing, .hero, .tagline, .install, .footer overrides from style.css
- changed landing wrapper from div to section for consistency
- tool pages now inherit layout from shared.css