### PR TITLE
077: fix password view quitting on q keypress

### DIFF
--- a/internal/tui/password.go
+++ b/internal/tui/password.go
@@ -50,7 +50,7 @@ func (m passwordModel) Init() tea.Cmd {
 func (m passwordModel) Update(msg tea.Msg) (passwordModel, tea.Cmd) {
 	switch msg := msg.(type) {
 	case tea.KeyMsg:
-		if key.Matches(msg, zstyle.KeyQuit) && msg.Type != tea.KeyEnter {
+		if msg.Type == tea.KeyCtrlC {
 			return m, tea.Quit
 		}
 

--- a/internal/tui/password_test.go
+++ b/internal/tui/password_test.go
@@ -1,0 +1,49 @@
+package tui
+
+import (
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+func TestPasswordModel_QKeyDoesNotQuit(t *testing.T) {
+	m := newPasswordModel(false)
+
+	msg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'q'}}
+	_, cmd := m.Update(msg)
+
+	if cmd != nil {
+		// execute the cmd to see what message it produces
+		result := cmd()
+		if _, ok := result.(tea.QuitMsg); ok {
+			t.Fatal("pressing 'q' should not quit the password view")
+		}
+	}
+}
+
+func TestPasswordModel_CtrlCQuits(t *testing.T) {
+	m := newPasswordModel(false)
+
+	msg := tea.KeyMsg{Type: tea.KeyCtrlC}
+	_, cmd := m.Update(msg)
+
+	if cmd == nil {
+		t.Fatal("ctrl+c should produce a quit command")
+	}
+
+	result := cmd()
+	if _, ok := result.(tea.QuitMsg); !ok {
+		t.Fatalf("ctrl+c should produce QuitMsg, got %T", result)
+	}
+}
+
+func TestPasswordModel_QKeyReachesTextInput(t *testing.T) {
+	m := newPasswordModel(false)
+
+	msg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'q'}}
+	updated, _ := m.Update(msg)
+
+	if updated.input.Value() != "q" {
+		t.Fatalf("expected textinput to contain %q, got %q", "q", updated.input.Value())
+	}
+}


### PR DESCRIPTION
Closes #33

Spec: zarlcorp/core/.manager/specs/077-password-quit-bug.md

Replace zstyle.KeyQuit check (matches q and ctrl+c) with explicit ctrl+c check in password model. The q key now reaches the textinput as a password character. Added 3 tests.