### PR TITLE
078: pass TAP_TOKEN to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,3 +11,5 @@ jobs:
     uses: zarlcorp/.github/.github/workflows/go-release.yml@main
     with:
       binary-name: zburn
+    secrets:
+      TAP_TOKEN: ${{ secrets.TAP_TOKEN }}


### PR DESCRIPTION
Part of 078: automate Homebrew tap update on release.

Passes TAP_TOKEN secret to the reusable go-release workflow so it can update the Homebrew formula automatically on release.