### PR TITLE
080: fix first-run password prompt

### DIFF
--- a/internal/tui/password.go
+++ b/internal/tui/password.go
@@ -105,9 +105,15 @@ func (m passwordModel) handleSubmit() (passwordModel, tea.Cmd) {
 func (m passwordModel) View() string {
 	title := zstyle.Title.Render("zburn")
 
-	prompt := "master password:"
-	if m.confirming {
-		prompt = "confirm password:"
+	var prompt string
+	if m.firstRun {
+		if m.confirming {
+			prompt = "confirm password:"
+		} else {
+			prompt = "create master password:"
+		}
+	} else {
+		prompt = "master password:"
 	}
 
 	s := fmt.Sprintf("\n  %s\n\n  %s\n  %s\n", title, prompt, m.input.View())

--- a/internal/tui/tui_test.go
+++ b/internal/tui/tui_test.go
@@ -53,8 +53,20 @@ func TestPasswordViewShowsPrompt(t *testing.T) {
 	if !strings.Contains(view, "master password") {
 		t.Error("view should show master password prompt")
 	}
+	if strings.Contains(view, "create") {
+		t.Error("non-first-run view should not contain 'create'")
+	}
 	if !strings.Contains(view, "zburn") {
 		t.Error("view should show title")
+	}
+}
+
+func TestPasswordFirstRunShowsCreate(t *testing.T) {
+	m := newPasswordModel(true)
+	view := m.View()
+
+	if !strings.Contains(view, "create master password") {
+		t.Error("first-run view should show 'create master password'")
 	}
 }
 


### PR DESCRIPTION
Closes #37

Spec: zarlcorp/core/.manager/specs/080-first-run-password-prompt.md

First-run prompt now shows 'create master password:' instead of 'master password:' so users know they're creating a new password.