### PR TITLE
084: fix logo alignment

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,10 +5,11 @@ go 1.26.0
 require (
 	github.com/charmbracelet/bubbles v1.0.0
 	github.com/charmbracelet/bubbletea v1.3.10
+	github.com/charmbracelet/lipgloss v1.1.0
 	github.com/zarlcorp/core/pkg/zapp v0.2.0
 	github.com/zarlcorp/core/pkg/zcrypto v0.2.0
 	github.com/zarlcorp/core/pkg/zfilesystem v0.3.0
-	github.com/zarlcorp/core/pkg/zstyle v0.3.0
+	github.com/zarlcorp/core/pkg/zstyle v0.4.0
 	golang.org/x/term v0.40.0
 )
 
@@ -18,7 +19,6 @@ require (
 	github.com/atotto/clipboard v0.1.4 // indirect
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
 	github.com/charmbracelet/colorprofile v0.4.1 // indirect
-	github.com/charmbracelet/lipgloss v1.1.0 // indirect
 	github.com/charmbracelet/x/ansi v0.11.6 // indirect
 	github.com/charmbracelet/x/cellbuf v0.0.15 // indirect
 	github.com/charmbracelet/x/term v0.2.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -56,8 +56,8 @@ github.com/zarlcorp/core/pkg/zfilesystem v0.3.0 h1:uYd27g7q5ZVhg+OLQOWpv6A0YBUm6
 github.com/zarlcorp/core/pkg/zfilesystem v0.3.0/go.mod h1:UfH2O9ttdQ+owzsHEHHNynWb9MNoryIeYNaMtAfQuxc=
 github.com/zarlcorp/core/pkg/zoptions v0.1.0 h1:/WgBilZ7tXGfqcq76nd8BOQv/JRaCsj7TLOXE5JNh7s=
 github.com/zarlcorp/core/pkg/zoptions v0.1.0/go.mod h1:JfZ/LnI9wEsmzXpSwmrFRIXCZARt3s9XMUt7UsSbo1s=
-github.com/zarlcorp/core/pkg/zstyle v0.3.0 h1:2JVoHI0d7KiYX9bRruB2ueSSYgmR3gX75NLvoysTLcY=
-github.com/zarlcorp/core/pkg/zstyle v0.3.0/go.mod h1:LIWzzyQZGVL9i7BsddIkWF02w1+4PAMr+KbtdtTapQk=
+github.com/zarlcorp/core/pkg/zstyle v0.4.0 h1:7VRSSLCJRzhqEQuLixJKZRNK5hyucKG0bdoFemn4CWQ=
+github.com/zarlcorp/core/pkg/zstyle v0.4.0/go.mod h1:LIWzzyQZGVL9i7BsddIkWF02w1+4PAMr+KbtdtTapQk=
 github.com/zarlcorp/core/pkg/zsync v0.1.0 h1:XR/HFKu+mK/4XkEAkTrcaiCOahyWxqBS5l6XhwgZJwI=
 github.com/zarlcorp/core/pkg/zsync v0.1.0/go.mod h1:uPnywnOHOaotnMrrSzPBeziPPZgtS0aEMZL1XcnrcO4=
 golang.org/x/crypto v0.48.0 h1:/VRzVqiRSggnhY7gNRxPauEQ5Drw9haKdM0jqfcCFts=

--- a/internal/tui/menu.go
+++ b/internal/tui/menu.go
@@ -91,10 +91,13 @@ func (m menuModel) selectItem() tea.Cmd {
 }
 
 func (m menuModel) View() string {
-	logo := zstyle.StyledLogo(lipgloss.NewStyle().Foreground(zstyle.ZburnAccent))
-	ver := zstyle.MutedText.Render("zburn " + m.version)
+	indent := lipgloss.NewStyle().MarginLeft(2)
+	logo := indent.Render(
+		zstyle.StyledLogo(lipgloss.NewStyle().Foreground(zstyle.ZburnAccent)),
+	)
+	ver := indent.Render(zstyle.MutedText.Render("zburn " + m.version))
 
-	s := fmt.Sprintf("\n  %s\n  %s\n\n", logo, ver)
+	s := fmt.Sprintf("\n%s\n%s\n\n", logo, ver)
 
 	for i, item := range menuItems {
 		if m.cursor == i {

--- a/internal/tui/password.go
+++ b/internal/tui/password.go
@@ -104,8 +104,11 @@ func (m passwordModel) handleSubmit() (passwordModel, tea.Cmd) {
 }
 
 func (m passwordModel) View() string {
-	logo := zstyle.StyledLogo(lipgloss.NewStyle().Foreground(zstyle.ZburnAccent))
-	toolName := zstyle.MutedText.Render("zburn")
+	indent := lipgloss.NewStyle().MarginLeft(2)
+	logo := indent.Render(
+		zstyle.StyledLogo(lipgloss.NewStyle().Foreground(zstyle.ZburnAccent)),
+	)
+	toolName := indent.Render(zstyle.MutedText.Render("zburn"))
 
 	var prompt string
 	if m.firstRun {
@@ -118,7 +121,7 @@ func (m passwordModel) View() string {
 		prompt = "master password:"
 	}
 
-	s := fmt.Sprintf("\n  %s\n  %s\n\n  %s\n  %s\n", logo, toolName, prompt, m.input.View())
+	s := fmt.Sprintf("\n%s\n%s\n\n  %s\n  %s\n", logo, toolName, prompt, m.input.View())
 
 	if m.errMsg != "" {
 		s += "\n  " + zstyle.StatusErr.Render(m.errMsg)


### PR DESCRIPTION
Closes #41

Spec: zarlcorp/core/.manager/specs/084-fix-logo-alignment.md

Fixes multiline logo alignment in password.go and menu.go by replacing fmt.Sprintf indent with lipgloss.MarginLeft(2). Also bumps zstyle to v0.4.0 (lowercase logo).