### PR TITLE
099: Namecheap email forwarding client

### DIFF
--- a/internal/namecheap/client.go
+++ b/internal/namecheap/client.go
@@ -1,0 +1,262 @@
+// Package namecheap provides a client for managing email forwarding rules
+// via the Namecheap API.
+package namecheap
+
+import (
+	"context"
+	"encoding/xml"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+)
+
+const defaultBaseURL = "https://api.namecheap.com/xml.response"
+
+// ForwardingRule maps a mailbox to a forwarding address.
+type ForwardingRule struct {
+	Mailbox   string // e.g. "john.doe" (the part before @)
+	ForwardTo string // e.g. "shared@gmail.com"
+}
+
+// Config holds credentials for the Namecheap API.
+type Config struct {
+	APIUser  string
+	APIKey   string
+	Username string
+	ClientIP string
+}
+
+// Client communicates with the Namecheap API.
+type Client struct {
+	cfg     Config
+	baseURL string
+	http    *http.Client
+}
+
+// NewClient creates a Namecheap API client.
+func NewClient(cfg Config) *Client {
+	return &Client{
+		cfg:     cfg,
+		baseURL: defaultBaseURL,
+		http:    http.DefaultClient,
+	}
+}
+
+// GetForwarding returns the current email forwarding rules for a domain.
+func (c *Client) GetForwarding(ctx context.Context, domain string) ([]ForwardingRule, error) {
+	sld, tld, err := splitDomain(domain)
+	if err != nil {
+		return nil, fmt.Errorf("get forwarding: %w", err)
+	}
+
+	params := c.baseParams("namecheap.domains.dns.getEmailForwarding")
+	params.Set("DomainName", domain)
+	params.Set("SLD", sld)
+	params.Set("TLD", tld)
+
+	body, err := c.do(ctx, params)
+	if err != nil {
+		return nil, fmt.Errorf("get forwarding: %w", err)
+	}
+
+	var resp apiResponse
+	if err := xml.Unmarshal(body, &resp); err != nil {
+		return nil, fmt.Errorf("get forwarding: parse response: %w", err)
+	}
+
+	if err := resp.err(); err != nil {
+		return nil, fmt.Errorf("get forwarding: %w", err)
+	}
+
+	var result getForwardingResult
+	if err := xml.Unmarshal(resp.CommandResponse.Raw, &result); err != nil {
+		return nil, fmt.Errorf("get forwarding: parse result: %w", err)
+	}
+
+	rules := make([]ForwardingRule, len(result.Forwards))
+	for i, f := range result.Forwards {
+		rules[i] = ForwardingRule{
+			Mailbox:   f.MailBox,
+			ForwardTo: f.ForwardTo,
+		}
+	}
+
+	return rules, nil
+}
+
+// SetForwarding replaces all email forwarding rules for a domain.
+// This is a destructive operation — any existing rules not included will be removed.
+func (c *Client) SetForwarding(ctx context.Context, domain string, rules []ForwardingRule) error {
+	sld, tld, err := splitDomain(domain)
+	if err != nil {
+		return fmt.Errorf("set forwarding: %w", err)
+	}
+
+	params := c.baseParams("namecheap.domains.dns.setEmailForwarding")
+	params.Set("DomainName", domain)
+	params.Set("SLD", sld)
+	params.Set("TLD", tld)
+
+	for i, r := range rules {
+		n := strconv.Itoa(i + 1)
+		params.Set("MailBox"+n, r.Mailbox)
+		params.Set("ForwardTo"+n, r.ForwardTo)
+	}
+
+	body, err := c.do(ctx, params)
+	if err != nil {
+		return fmt.Errorf("set forwarding: %w", err)
+	}
+
+	var resp apiResponse
+	if err := xml.Unmarshal(body, &resp); err != nil {
+		return fmt.Errorf("set forwarding: parse response: %w", err)
+	}
+
+	if err := resp.err(); err != nil {
+		return fmt.Errorf("set forwarding: %w", err)
+	}
+
+	return nil
+}
+
+// AddForwarding adds a forwarding rule without removing existing ones.
+// It fetches current rules, appends the new one, and sets all rules.
+func (c *Client) AddForwarding(ctx context.Context, domain, mailbox, forwardTo string) error {
+	rules, err := c.GetForwarding(ctx, domain)
+	if err != nil {
+		return fmt.Errorf("add forwarding: %w", err)
+	}
+
+	rules = append(rules, ForwardingRule{
+		Mailbox:   mailbox,
+		ForwardTo: forwardTo,
+	})
+
+	if err := c.SetForwarding(ctx, domain, rules); err != nil {
+		return fmt.Errorf("add forwarding: %w", err)
+	}
+
+	return nil
+}
+
+// RemoveForwarding removes a forwarding rule by mailbox name.
+// It fetches current rules, removes the matching one, and sets the remaining rules.
+func (c *Client) RemoveForwarding(ctx context.Context, domain, mailbox string) error {
+	rules, err := c.GetForwarding(ctx, domain)
+	if err != nil {
+		return fmt.Errorf("remove forwarding: %w", err)
+	}
+
+	filtered := rules[:0]
+	for _, r := range rules {
+		if r.Mailbox != mailbox {
+			filtered = append(filtered, r)
+		}
+	}
+
+	if len(filtered) == len(rules) {
+		return fmt.Errorf("remove forwarding: mailbox %q not found", mailbox)
+	}
+
+	if err := c.SetForwarding(ctx, domain, filtered); err != nil {
+		return fmt.Errorf("remove forwarding: %w", err)
+	}
+
+	return nil
+}
+
+func (c *Client) baseParams(command string) url.Values {
+	return url.Values{
+		"ApiUser":  {c.cfg.APIUser},
+		"ApiKey":   {c.cfg.APIKey},
+		"UserName": {c.cfg.Username},
+		"ClientIp": {c.cfg.ClientIP},
+		"Command":  {command},
+	}
+}
+
+func (c *Client) do(ctx context.Context, params url.Values) ([]byte, error) {
+	u := c.baseURL + "?" + params.Encode()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
+	if err != nil {
+		return nil, fmt.Errorf("create request: %w", err)
+	}
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("execute request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read response: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unexpected status %d", resp.StatusCode)
+	}
+
+	return body, nil
+}
+
+func splitDomain(domain string) (sld, tld string, err error) {
+	parts := strings.SplitN(domain, ".", 2)
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		return "", "", fmt.Errorf("invalid domain %q", domain)
+	}
+	return parts[0], parts[1], nil
+}
+
+// xml response types
+
+type apiResponse struct {
+	XMLName         xml.Name        `xml:"ApiResponse"`
+	Status          string          `xml:"Status,attr"`
+	Errors          apiErrors       `xml:"Errors"`
+	CommandResponse commandResponse `xml:"CommandResponse"`
+}
+
+func (r *apiResponse) err() error {
+	if r.Status == "OK" {
+		return nil
+	}
+
+	if len(r.Errors.Items) > 0 {
+		msgs := make([]string, len(r.Errors.Items))
+		for i, e := range r.Errors.Items {
+			msgs[i] = e.Message
+		}
+		return fmt.Errorf("api: %s", strings.Join(msgs, "; "))
+	}
+
+	return fmt.Errorf("api: status %s", r.Status)
+}
+
+type apiErrors struct {
+	Items []apiError `xml:"Error"`
+}
+
+type apiError struct {
+	Number  string `xml:"Number,attr"`
+	Message string `xml:",chardata"`
+}
+
+type commandResponse struct {
+	Raw []byte `xml:",innerxml"`
+}
+
+type getForwardingResult struct {
+	XMLName  xml.Name          `xml:"DomainDNSGetEmailForwardingResult"`
+	Forwards []forwardingEntry `xml:"Forward"`
+}
+
+type forwardingEntry struct {
+	MailBox   string `xml:"mailbox,attr"`
+	ForwardTo string `xml:",chardata"`
+}

--- a/internal/namecheap/client_test.go
+++ b/internal/namecheap/client_test.go
@@ -1,0 +1,438 @@
+package namecheap
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// canned XML responses
+
+const getForwardingOK = `<?xml version="1.0" encoding="utf-8"?>
+<ApiResponse Status="OK" xmlns="http://api.namecheap.com/xml.response">
+  <Errors />
+  <RequestedCommand>namecheap.domains.dns.getEmailForwarding</RequestedCommand>
+  <CommandResponse Type="namecheap.domains.dns.getEmailForwarding">
+    <DomainDNSGetEmailForwardingResult Domain="example.com" IsOwner="true">
+      <Forward mailbox="alice">shared@gmail.com</Forward>
+      <Forward mailbox="bob">shared@gmail.com</Forward>
+    </DomainDNSGetEmailForwardingResult>
+  </CommandResponse>
+  <Server>SERVER</Server>
+  <GMTTimeDifference>--5:00</GMTTimeDifference>
+  <ExecutionTime>0.5</ExecutionTime>
+</ApiResponse>`
+
+const getForwardingEmpty = `<?xml version="1.0" encoding="utf-8"?>
+<ApiResponse Status="OK" xmlns="http://api.namecheap.com/xml.response">
+  <Errors />
+  <CommandResponse Type="namecheap.domains.dns.getEmailForwarding">
+    <DomainDNSGetEmailForwardingResult Domain="example.com" IsOwner="true">
+    </DomainDNSGetEmailForwardingResult>
+  </CommandResponse>
+</ApiResponse>`
+
+const setForwardingOK = `<?xml version="1.0" encoding="utf-8"?>
+<ApiResponse Status="OK" xmlns="http://api.namecheap.com/xml.response">
+  <Errors />
+  <CommandResponse Type="namecheap.domains.dns.setEmailForwarding">
+    <DomainDNSSetEmailForwardingResult Domain="example.com" IsSuccess="true" />
+  </CommandResponse>
+</ApiResponse>`
+
+const apiErrorResponse = `<?xml version="1.0" encoding="utf-8"?>
+<ApiResponse Status="ERROR" xmlns="http://api.namecheap.com/xml.response">
+  <Errors>
+    <Error Number="2019166">Domain not found</Error>
+  </Errors>
+  <CommandResponse />
+</ApiResponse>`
+
+const apiMultiErrorResponse = `<?xml version="1.0" encoding="utf-8"?>
+<ApiResponse Status="ERROR" xmlns="http://api.namecheap.com/xml.response">
+  <Errors>
+    <Error Number="1010101">Invalid API key</Error>
+    <Error Number="1010102">IP not whitelisted</Error>
+  </Errors>
+  <CommandResponse />
+</ApiResponse>`
+
+func testConfig() Config {
+	return Config{
+		APIUser:  "testuser",
+		APIKey:   "testkey",
+		Username: "testuser",
+		ClientIP: "1.2.3.4",
+	}
+}
+
+func newTestClient(url string) *Client {
+	c := NewClient(testConfig())
+	c.baseURL = url
+	return c
+}
+
+func TestGetForwarding(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assertQueryParam(t, r, "Command", "namecheap.domains.dns.getEmailForwarding")
+		assertQueryParam(t, r, "SLD", "example")
+		assertQueryParam(t, r, "TLD", "com")
+		assertQueryParam(t, r, "DomainName", "example.com")
+		assertQueryParam(t, r, "ApiUser", "testuser")
+		assertQueryParam(t, r, "ApiKey", "testkey")
+		assertQueryParam(t, r, "ClientIp", "1.2.3.4")
+
+		w.Header().Set("Content-Type", "text/xml")
+		w.Write([]byte(getForwardingOK))
+	}))
+	defer srv.Close()
+
+	c := newTestClient(srv.URL)
+	rules, err := c.GetForwarding(context.Background(), "example.com")
+	if err != nil {
+		t.Fatalf("get forwarding: %v", err)
+	}
+
+	if len(rules) != 2 {
+		t.Fatalf("rules count: got %d, want 2", len(rules))
+	}
+
+	want := []ForwardingRule{
+		{Mailbox: "alice", ForwardTo: "shared@gmail.com"},
+		{Mailbox: "bob", ForwardTo: "shared@gmail.com"},
+	}
+	for i, r := range rules {
+		if r != want[i] {
+			t.Errorf("rule[%d]: got %+v, want %+v", i, r, want[i])
+		}
+	}
+}
+
+func TestGetForwardingEmpty(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Write([]byte(getForwardingEmpty))
+	}))
+	defer srv.Close()
+
+	c := newTestClient(srv.URL)
+	rules, err := c.GetForwarding(context.Background(), "example.com")
+	if err != nil {
+		t.Fatalf("get forwarding: %v", err)
+	}
+
+	if len(rules) != 0 {
+		t.Fatalf("rules count: got %d, want 0", len(rules))
+	}
+}
+
+func TestSetForwarding(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assertQueryParam(t, r, "Command", "namecheap.domains.dns.setEmailForwarding")
+		assertQueryParam(t, r, "SLD", "example")
+		assertQueryParam(t, r, "TLD", "com")
+		assertQueryParam(t, r, "MailBox1", "alice")
+		assertQueryParam(t, r, "ForwardTo1", "shared@gmail.com")
+		assertQueryParam(t, r, "MailBox2", "bob")
+		assertQueryParam(t, r, "ForwardTo2", "other@gmail.com")
+
+		w.Write([]byte(setForwardingOK))
+	}))
+	defer srv.Close()
+
+	c := newTestClient(srv.URL)
+	err := c.SetForwarding(context.Background(), "example.com", []ForwardingRule{
+		{Mailbox: "alice", ForwardTo: "shared@gmail.com"},
+		{Mailbox: "bob", ForwardTo: "other@gmail.com"},
+	})
+	if err != nil {
+		t.Fatalf("set forwarding: %v", err)
+	}
+}
+
+func TestAddForwardingPreservesExisting(t *testing.T) {
+	callCount := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		cmd := r.URL.Query().Get("Command")
+		callCount++
+
+		switch cmd {
+		case "namecheap.domains.dns.getEmailForwarding":
+			w.Write([]byte(getForwardingOK))
+		case "namecheap.domains.dns.setEmailForwarding":
+			// verify all three rules are present
+			assertQueryParam(t, r, "MailBox1", "alice")
+			assertQueryParam(t, r, "ForwardTo1", "shared@gmail.com")
+			assertQueryParam(t, r, "MailBox2", "bob")
+			assertQueryParam(t, r, "ForwardTo2", "shared@gmail.com")
+			assertQueryParam(t, r, "MailBox3", "charlie")
+			assertQueryParam(t, r, "ForwardTo3", "other@gmail.com")
+			w.Write([]byte(setForwardingOK))
+		default:
+			t.Errorf("unexpected command: %s", cmd)
+		}
+	}))
+	defer srv.Close()
+
+	c := newTestClient(srv.URL)
+	err := c.AddForwarding(context.Background(), "example.com", "charlie", "other@gmail.com")
+	if err != nil {
+		t.Fatalf("add forwarding: %v", err)
+	}
+
+	if callCount != 2 {
+		t.Errorf("call count: got %d, want 2 (get + set)", callCount)
+	}
+}
+
+func TestAddForwardingToEmpty(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		cmd := r.URL.Query().Get("Command")
+
+		switch cmd {
+		case "namecheap.domains.dns.getEmailForwarding":
+			w.Write([]byte(getForwardingEmpty))
+		case "namecheap.domains.dns.setEmailForwarding":
+			assertQueryParam(t, r, "MailBox1", "first")
+			assertQueryParam(t, r, "ForwardTo1", "dest@gmail.com")
+
+			// verify no second rule
+			if v := r.URL.Query().Get("MailBox2"); v != "" {
+				t.Errorf("unexpected MailBox2: %s", v)
+			}
+
+			w.Write([]byte(setForwardingOK))
+		default:
+			t.Errorf("unexpected command: %s", cmd)
+		}
+	}))
+	defer srv.Close()
+
+	c := newTestClient(srv.URL)
+	err := c.AddForwarding(context.Background(), "example.com", "first", "dest@gmail.com")
+	if err != nil {
+		t.Fatalf("add forwarding: %v", err)
+	}
+}
+
+func TestRemoveForwarding(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		cmd := r.URL.Query().Get("Command")
+
+		switch cmd {
+		case "namecheap.domains.dns.getEmailForwarding":
+			w.Write([]byte(getForwardingOK))
+		case "namecheap.domains.dns.setEmailForwarding":
+			// alice removed, only bob remains
+			assertQueryParam(t, r, "MailBox1", "bob")
+			assertQueryParam(t, r, "ForwardTo1", "shared@gmail.com")
+
+			if v := r.URL.Query().Get("MailBox2"); v != "" {
+				t.Errorf("unexpected MailBox2: %s", v)
+			}
+
+			w.Write([]byte(setForwardingOK))
+		default:
+			t.Errorf("unexpected command: %s", cmd)
+		}
+	}))
+	defer srv.Close()
+
+	c := newTestClient(srv.URL)
+	err := c.RemoveForwarding(context.Background(), "example.com", "alice")
+	if err != nil {
+		t.Fatalf("remove forwarding: %v", err)
+	}
+}
+
+func TestRemoveForwardingNotFound(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Write([]byte(getForwardingOK))
+	}))
+	defer srv.Close()
+
+	c := newTestClient(srv.URL)
+	err := c.RemoveForwarding(context.Background(), "example.com", "nonexistent")
+	if err == nil {
+		t.Fatal("expected error for nonexistent mailbox")
+	}
+	if !strings.Contains(err.Error(), `mailbox "nonexistent" not found`) {
+		t.Errorf("error message: got %q, want contains mailbox not found", err.Error())
+	}
+}
+
+func TestAPIError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Write([]byte(apiErrorResponse))
+	}))
+	defer srv.Close()
+
+	c := newTestClient(srv.URL)
+	_, err := c.GetForwarding(context.Background(), "example.com")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "Domain not found") {
+		t.Errorf("error: got %q, want contains 'Domain not found'", err.Error())
+	}
+}
+
+func TestAPIMultipleErrors(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Write([]byte(apiMultiErrorResponse))
+	}))
+	defer srv.Close()
+
+	c := newTestClient(srv.URL)
+	_, err := c.GetForwarding(context.Background(), "example.com")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "Invalid API key") {
+		t.Errorf("error: got %q, want contains 'Invalid API key'", err.Error())
+	}
+	if !strings.Contains(err.Error(), "IP not whitelisted") {
+		t.Errorf("error: got %q, want contains 'IP not whitelisted'", err.Error())
+	}
+}
+
+func TestHTTPError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		w.Write([]byte("internal error"))
+	}))
+	defer srv.Close()
+
+	c := newTestClient(srv.URL)
+	_, err := c.GetForwarding(context.Background(), "example.com")
+	if err == nil {
+		t.Fatal("expected error for 500 response")
+	}
+	if !strings.Contains(err.Error(), "unexpected status 500") {
+		t.Errorf("error: got %q, want contains 'unexpected status 500'", err.Error())
+	}
+}
+
+func TestNetworkError(t *testing.T) {
+	// point at a closed server
+	srv := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	srv.Close()
+
+	c := newTestClient(srv.URL)
+	_, err := c.GetForwarding(context.Background(), "example.com")
+	if err == nil {
+		t.Fatal("expected error for unreachable server")
+	}
+}
+
+func TestMalformedXML(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Write([]byte("this is not xml"))
+	}))
+	defer srv.Close()
+
+	c := newTestClient(srv.URL)
+	_, err := c.GetForwarding(context.Background(), "example.com")
+	if err == nil {
+		t.Fatal("expected error for malformed XML")
+	}
+	if !strings.Contains(err.Error(), "parse response") {
+		t.Errorf("error: got %q, want contains 'parse response'", err.Error())
+	}
+}
+
+func TestInvalidDomain(t *testing.T) {
+	c := NewClient(testConfig())
+
+	tests := []string{
+		"nodot",
+		".leading",
+		"trailing.",
+		"",
+	}
+
+	for _, d := range tests {
+		_, err := c.GetForwarding(context.Background(), d)
+		if err == nil {
+			t.Errorf("expected error for domain %q", d)
+		}
+	}
+}
+
+func TestSplitDomain(t *testing.T) {
+	tests := []struct {
+		domain  string
+		sld     string
+		tld     string
+		wantErr bool
+	}{
+		{"example.com", "example", "com", false},
+		{"my.co.uk", "my", "co.uk", false},
+		{"sub.example.org", "sub", "example.org", false},
+		{"nodot", "", "", true},
+		{"", "", "", true},
+		{".com", "", "", true},
+		{"example.", "", "", true},
+	}
+
+	for _, tt := range tests {
+		sld, tld, err := splitDomain(tt.domain)
+		if tt.wantErr {
+			if err == nil {
+				t.Errorf("splitDomain(%q): want error, got nil", tt.domain)
+			}
+			continue
+		}
+		if err != nil {
+			t.Errorf("splitDomain(%q): %v", tt.domain, err)
+			continue
+		}
+		if sld != tt.sld || tld != tt.tld {
+			t.Errorf("splitDomain(%q): got (%q, %q), want (%q, %q)", tt.domain, sld, tld, tt.sld, tt.tld)
+		}
+	}
+}
+
+func TestSetForwardingAPIError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Write([]byte(apiErrorResponse))
+	}))
+	defer srv.Close()
+
+	c := newTestClient(srv.URL)
+	err := c.SetForwarding(context.Background(), "example.com", []ForwardingRule{
+		{Mailbox: "test", ForwardTo: "dest@gmail.com"},
+	})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "Domain not found") {
+		t.Errorf("error: got %q, want contains 'Domain not found'", err.Error())
+	}
+}
+
+func TestContextCancellation(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Write([]byte(getForwardingOK))
+	}))
+	defer srv.Close()
+
+	c := newTestClient(srv.URL)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // cancel immediately
+
+	_, err := c.GetForwarding(ctx, "example.com")
+	if err == nil {
+		t.Fatal("expected error for cancelled context")
+	}
+}
+
+func assertQueryParam(t *testing.T, r *http.Request, key, want string) {
+	t.Helper()
+	got := r.URL.Query().Get(key)
+	if got != want {
+		t.Errorf("query param %s: got %q, want %q", key, got, want)
+	}
+}


### PR DESCRIPTION
Closes #46

Spec: zarlcorp/core/.manager/specs/099-namecheap-email-forwarding.md

Internal Namecheap API client for managing email forwarding rules. Supports Get/Set/Add/Remove forwarding with XML parsing. All tests use httptest — no real API calls.