### PR TITLE
101: Twilio SMS client

### DIFF
--- a/internal/twilio/client.go
+++ b/internal/twilio/client.go
@@ -1,0 +1,288 @@
+// Package twilio provides a client for provisioning phone numbers and reading
+// incoming SMS messages via the Twilio REST API.
+package twilio
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+// Config holds Twilio API credentials.
+type Config struct {
+	AccountSID string
+	AuthToken  string
+}
+
+// AvailableNumber represents a phone number available for purchase.
+type AvailableNumber struct {
+	PhoneNumber  string
+	FriendlyName string
+	Capabilities struct {
+		SMS   bool
+		Voice bool
+	}
+}
+
+// PhoneNumber represents a provisioned incoming phone number.
+type PhoneNumber struct {
+	SID          string
+	PhoneNumber  string
+	FriendlyName string
+}
+
+// SMSMessage represents an SMS message.
+type SMSMessage struct {
+	SID      string
+	From     string
+	To       string
+	Body     string
+	DateSent time.Time
+	Status   string
+}
+
+// Client communicates with the Twilio REST API.
+type Client struct {
+	accountSID string
+	authToken  string
+	baseURL    string
+	http       *http.Client
+}
+
+// NewClient creates a Twilio client with the given credentials.
+func NewClient(cfg Config) *Client {
+	return &Client{
+		accountSID: cfg.AccountSID,
+		authToken:  cfg.AuthToken,
+		baseURL:    "https://api.twilio.com/2010-04-01/Accounts/" + cfg.AccountSID,
+		http:       &http.Client{Timeout: 30 * time.Second},
+	}
+}
+
+// SearchNumbers returns available local phone numbers for a country.
+// country is an ISO country code (e.g. "GB", "US").
+func (c *Client) SearchNumbers(ctx context.Context, country string) ([]AvailableNumber, error) {
+	u := c.baseURL + "/AvailablePhoneNumbers/" + country + "/Local.json"
+
+	body, err := c.doGet(ctx, u)
+	if err != nil {
+		return nil, fmt.Errorf("search numbers: %w", err)
+	}
+
+	var resp availableNumbersResponse
+	if err := json.Unmarshal(body, &resp); err != nil {
+		return nil, fmt.Errorf("search numbers: unmarshal: %w", err)
+	}
+
+	numbers := make([]AvailableNumber, len(resp.AvailablePhoneNumbers))
+	for i, n := range resp.AvailablePhoneNumbers {
+		numbers[i] = AvailableNumber{
+			PhoneNumber:  n.PhoneNumber,
+			FriendlyName: n.FriendlyName,
+		}
+		numbers[i].Capabilities.SMS = n.Capabilities.SMS
+		numbers[i].Capabilities.Voice = n.Capabilities.Voice
+	}
+
+	return numbers, nil
+}
+
+// BuyNumber purchases a phone number and returns the provisioned details.
+func (c *Client) BuyNumber(ctx context.Context, phoneNumber string) (*PhoneNumber, error) {
+	u := c.baseURL + "/IncomingPhoneNumbers.json"
+
+	form := url.Values{}
+	form.Set("PhoneNumber", phoneNumber)
+
+	body, err := c.doPost(ctx, u, form)
+	if err != nil {
+		return nil, fmt.Errorf("buy number: %w", err)
+	}
+
+	var resp phoneNumberResponse
+	if err := json.Unmarshal(body, &resp); err != nil {
+		return nil, fmt.Errorf("buy number: unmarshal: %w", err)
+	}
+
+	return &PhoneNumber{
+		SID:          resp.SID,
+		PhoneNumber:  resp.PhoneNumber,
+		FriendlyName: resp.FriendlyName,
+	}, nil
+}
+
+// ReleaseNumber releases a provisioned phone number back to Twilio.
+func (c *Client) ReleaseNumber(ctx context.Context, numberSID string) error {
+	u := c.baseURL + "/IncomingPhoneNumbers/" + numberSID + ".json"
+
+	if err := c.doDelete(ctx, u); err != nil {
+		return fmt.Errorf("release number: %w", err)
+	}
+
+	return nil
+}
+
+// ListMessages returns recent SMS messages sent to the given number.
+// Results are ordered by date descending (most recent first).
+func (c *Client) ListMessages(ctx context.Context, to string, limit int) ([]SMSMessage, error) {
+	u := c.baseURL + "/Messages.json?To=" + url.QueryEscape(to) + "&PageSize=" + fmt.Sprintf("%d", limit)
+
+	body, err := c.doGet(ctx, u)
+	if err != nil {
+		return nil, fmt.Errorf("list messages: %w", err)
+	}
+
+	var resp messagesResponse
+	if err := json.Unmarshal(body, &resp); err != nil {
+		return nil, fmt.Errorf("list messages: unmarshal: %w", err)
+	}
+
+	messages := make([]SMSMessage, len(resp.Messages))
+	for i, m := range resp.Messages {
+		t, _ := time.Parse(time.RFC1123Z, m.DateSent)
+		messages[i] = SMSMessage{
+			SID:      m.SID,
+			From:     m.From,
+			To:       m.To,
+			Body:     m.Body,
+			DateSent: t,
+			Status:   m.Status,
+		}
+	}
+
+	return messages, nil
+}
+
+func (c *Client) doGet(ctx context.Context, u string) ([]byte, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
+	if err != nil {
+		return nil, fmt.Errorf("create request: %w", err)
+	}
+
+	return c.do(req)
+}
+
+func (c *Client) doPost(ctx context.Context, u string, form url.Values) ([]byte, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, u, strings.NewReader(form.Encode()))
+	if err != nil {
+		return nil, fmt.Errorf("create request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	return c.do(req)
+}
+
+func (c *Client) doDelete(ctx context.Context, u string) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, u, nil)
+	if err != nil {
+		return fmt.Errorf("create request: %w", err)
+	}
+
+	resp, err := c.doRaw(req)
+	if err != nil {
+		return err
+	}
+	resp.Body.Close()
+
+	return nil
+}
+
+func (c *Client) do(req *http.Request) ([]byte, error) {
+	resp, err := c.doRaw(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read response: %w", err)
+	}
+
+	return body, nil
+}
+
+func (c *Client) doRaw(req *http.Request) (*http.Response, error) {
+	req.SetBasicAuth(c.accountSID, c.authToken)
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("http request: %w", err)
+	}
+
+	if resp.StatusCode >= 400 {
+		body, _ := io.ReadAll(resp.Body)
+		resp.Body.Close()
+
+		var apiErr apiErrorResponse
+		if err := json.Unmarshal(body, &apiErr); err == nil && apiErr.Message != "" {
+			return nil, &Error{
+				StatusCode: resp.StatusCode,
+				Code:       apiErr.Code,
+				Message:    apiErr.Message,
+			}
+		}
+
+		return nil, &Error{
+			StatusCode: resp.StatusCode,
+			Message:    http.StatusText(resp.StatusCode),
+		}
+	}
+
+	return resp, nil
+}
+
+// Error represents a Twilio API error.
+type Error struct {
+	StatusCode int
+	Code       int
+	Message    string
+}
+
+func (e *Error) Error() string {
+	if e.Code != 0 {
+		return fmt.Sprintf("twilio: %s (code %d, status %d)", e.Message, e.Code, e.StatusCode)
+	}
+	return fmt.Sprintf("twilio: %s (status %d)", e.Message, e.StatusCode)
+}
+
+// json wire types for API responses
+
+type availableNumbersResponse struct {
+	AvailablePhoneNumbers []struct {
+		PhoneNumber  string `json:"phone_number"`
+		FriendlyName string `json:"friendly_name"`
+		Capabilities struct {
+			SMS   bool `json:"sms"`
+			Voice bool `json:"voice"`
+		} `json:"capabilities"`
+	} `json:"available_phone_numbers"`
+}
+
+type phoneNumberResponse struct {
+	SID          string `json:"sid"`
+	PhoneNumber  string `json:"phone_number"`
+	FriendlyName string `json:"friendly_name"`
+}
+
+type messagesResponse struct {
+	Messages []struct {
+		SID      string `json:"sid"`
+		From     string `json:"from"`
+		To       string `json:"to"`
+		Body     string `json:"body"`
+		DateSent string `json:"date_sent"`
+		Status   string `json:"status"`
+	} `json:"messages"`
+}
+
+type apiErrorResponse struct {
+	Code    int    `json:"code"`
+	Message string `json:"message"`
+	Status  int    `json:"status"`
+}

--- a/internal/twilio/client_test.go
+++ b/internal/twilio/client_test.go
@@ -1,0 +1,415 @@
+package twilio
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func testClient(t *testing.T, handler http.Handler) *Client {
+	t.Helper()
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+
+	c := NewClient(Config{
+		AccountSID: "AC_test_sid",
+		AuthToken:  "test_auth_token",
+	})
+	c.baseURL = srv.URL
+	return c
+}
+
+func TestBasicAuthHeader(t *testing.T) {
+	var gotUser, gotPass string
+	var gotAuth bool
+
+	c := testClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotUser, gotPass, gotAuth = r.BasicAuth()
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(map[string]any{"available_phone_numbers": []any{}})
+	}))
+
+	_, _ = c.SearchNumbers(context.Background(), "US")
+
+	if !gotAuth {
+		t.Fatal("basic auth not set")
+	}
+	if gotUser != "AC_test_sid" {
+		t.Errorf("user: got %q, want %q", gotUser, "AC_test_sid")
+	}
+	if gotPass != "test_auth_token" {
+		t.Errorf("pass: got %q, want %q", gotPass, "test_auth_token")
+	}
+}
+
+func TestSearchNumbers(t *testing.T) {
+	c := testClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("method: got %s, want GET", r.Method)
+		}
+		if want := "/AvailablePhoneNumbers/GB/Local.json"; r.URL.Path != want {
+			t.Errorf("path: got %s, want %s", r.URL.Path, want)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"available_phone_numbers": []map[string]any{
+				{
+					"phone_number":  "+441234567890",
+					"friendly_name": "(123) 456-7890",
+					"capabilities":  map[string]bool{"sms": true, "voice": true},
+				},
+				{
+					"phone_number":  "+441234567891",
+					"friendly_name": "(123) 456-7891",
+					"capabilities":  map[string]bool{"sms": true, "voice": false},
+				},
+			},
+		})
+	}))
+
+	numbers, err := c.SearchNumbers(context.Background(), "GB")
+	if err != nil {
+		t.Fatalf("search: %v", err)
+	}
+
+	if len(numbers) != 2 {
+		t.Fatalf("count: got %d, want 2", len(numbers))
+	}
+
+	if numbers[0].PhoneNumber != "+441234567890" {
+		t.Errorf("numbers[0].PhoneNumber: got %q", numbers[0].PhoneNumber)
+	}
+	if numbers[0].FriendlyName != "(123) 456-7890" {
+		t.Errorf("numbers[0].FriendlyName: got %q", numbers[0].FriendlyName)
+	}
+	if !numbers[0].Capabilities.SMS {
+		t.Error("numbers[0] should have SMS capability")
+	}
+	if !numbers[0].Capabilities.Voice {
+		t.Error("numbers[0] should have Voice capability")
+	}
+	if numbers[1].Capabilities.Voice {
+		t.Error("numbers[1] should not have Voice capability")
+	}
+}
+
+func TestSearchNumbersEmptyResult(t *testing.T) {
+	c := testClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]any{"available_phone_numbers": []any{}})
+	}))
+
+	numbers, err := c.SearchNumbers(context.Background(), "US")
+	if err != nil {
+		t.Fatalf("search: %v", err)
+	}
+
+	if len(numbers) != 0 {
+		t.Fatalf("count: got %d, want 0", len(numbers))
+	}
+}
+
+func TestBuyNumber(t *testing.T) {
+	c := testClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("method: got %s, want POST", r.Method)
+		}
+		if want := "/IncomingPhoneNumbers.json"; r.URL.Path != want {
+			t.Errorf("path: got %s, want %s", r.URL.Path, want)
+		}
+		if ct := r.Header.Get("Content-Type"); ct != "application/x-www-form-urlencoded" {
+			t.Errorf("content-type: got %q", ct)
+		}
+
+		if err := r.ParseForm(); err != nil {
+			t.Fatalf("parse form: %v", err)
+		}
+		if got := r.PostFormValue("PhoneNumber"); got != "+15551234567" {
+			t.Errorf("PhoneNumber param: got %q", got)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]string{
+			"sid":           "PN_test_number_sid",
+			"phone_number":  "+15551234567",
+			"friendly_name": "(555) 123-4567",
+		})
+	}))
+
+	pn, err := c.BuyNumber(context.Background(), "+15551234567")
+	if err != nil {
+		t.Fatalf("buy: %v", err)
+	}
+
+	if pn.SID != "PN_test_number_sid" {
+		t.Errorf("SID: got %q", pn.SID)
+	}
+	if pn.PhoneNumber != "+15551234567" {
+		t.Errorf("PhoneNumber: got %q", pn.PhoneNumber)
+	}
+	if pn.FriendlyName != "(555) 123-4567" {
+		t.Errorf("FriendlyName: got %q", pn.FriendlyName)
+	}
+}
+
+func TestReleaseNumber(t *testing.T) {
+	c := testClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodDelete {
+			t.Errorf("method: got %s, want DELETE", r.Method)
+		}
+		if want := "/IncomingPhoneNumbers/PN_test_sid.json"; r.URL.Path != want {
+			t.Errorf("path: got %s, want %s", r.URL.Path, want)
+		}
+
+		w.WriteHeader(http.StatusNoContent)
+	}))
+
+	if err := c.ReleaseNumber(context.Background(), "PN_test_sid"); err != nil {
+		t.Fatalf("release: %v", err)
+	}
+}
+
+func TestListMessages(t *testing.T) {
+	c := testClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("method: got %s, want GET", r.Method)
+		}
+
+		q := r.URL.Query()
+		if got := q.Get("To"); got != "+15551234567" {
+			t.Errorf("To param: got %q", got)
+		}
+		if got := q.Get("PageSize"); got != "5" {
+			t.Errorf("PageSize param: got %q", got)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"messages": []map[string]string{
+				{
+					"sid":       "SM_msg1",
+					"from":      "+15559876543",
+					"to":        "+15551234567",
+					"body":      "Your code is 123456",
+					"date_sent": "Mon, 16 Feb 2026 10:30:00 +0000",
+					"status":    "received",
+				},
+				{
+					"sid":       "SM_msg2",
+					"from":      "+15559876544",
+					"to":        "+15551234567",
+					"body":      "Welcome to the service",
+					"date_sent": "Mon, 16 Feb 2026 09:00:00 +0000",
+					"status":    "received",
+				},
+			},
+		})
+	}))
+
+	msgs, err := c.ListMessages(context.Background(), "+15551234567", 5)
+	if err != nil {
+		t.Fatalf("list messages: %v", err)
+	}
+
+	if len(msgs) != 2 {
+		t.Fatalf("count: got %d, want 2", len(msgs))
+	}
+
+	if msgs[0].SID != "SM_msg1" {
+		t.Errorf("msgs[0].SID: got %q", msgs[0].SID)
+	}
+	if msgs[0].From != "+15559876543" {
+		t.Errorf("msgs[0].From: got %q", msgs[0].From)
+	}
+	if msgs[0].To != "+15551234567" {
+		t.Errorf("msgs[0].To: got %q", msgs[0].To)
+	}
+	if msgs[0].Body != "Your code is 123456" {
+		t.Errorf("msgs[0].Body: got %q", msgs[0].Body)
+	}
+	if msgs[0].Status != "received" {
+		t.Errorf("msgs[0].Status: got %q", msgs[0].Status)
+	}
+	if msgs[0].DateSent.IsZero() {
+		t.Error("msgs[0].DateSent is zero")
+	}
+}
+
+func TestListMessagesEmpty(t *testing.T) {
+	c := testClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]any{"messages": []any{}})
+	}))
+
+	msgs, err := c.ListMessages(context.Background(), "+15551234567", 10)
+	if err != nil {
+		t.Fatalf("list messages: %v", err)
+	}
+
+	if len(msgs) != 0 {
+		t.Fatalf("count: got %d, want 0", len(msgs))
+	}
+}
+
+func TestErrorInsufficientFunds(t *testing.T) {
+	c := testClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusPaymentRequired)
+		json.NewEncoder(w).Encode(map[string]any{
+			"code":    20003,
+			"message": "Insufficient funds",
+			"status":  402,
+		})
+	}))
+
+	_, err := c.BuyNumber(context.Background(), "+15551234567")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+
+	var twilioErr *Error
+	if !errors.As(err, &twilioErr) {
+		t.Fatalf("expected *Error, got %T: %v", err, err)
+	}
+
+	if twilioErr.StatusCode != 402 {
+		t.Errorf("status: got %d, want 402", twilioErr.StatusCode)
+	}
+	if twilioErr.Code != 20003 {
+		t.Errorf("code: got %d, want 20003", twilioErr.Code)
+	}
+	if twilioErr.Message != "Insufficient funds" {
+		t.Errorf("message: got %q", twilioErr.Message)
+	}
+}
+
+func TestErrorNumberUnavailable(t *testing.T) {
+	c := testClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		json.NewEncoder(w).Encode(map[string]any{
+			"code":    21422,
+			"message": "Phone number is not available",
+			"status":  400,
+		})
+	}))
+
+	_, err := c.BuyNumber(context.Background(), "+15551234567")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+
+	var twilioErr *Error
+	if !errors.As(err, &twilioErr) {
+		t.Fatalf("expected *Error, got %T: %v", err, err)
+	}
+
+	if twilioErr.StatusCode != 400 {
+		t.Errorf("status: got %d, want 400", twilioErr.StatusCode)
+	}
+	if twilioErr.Code != 21422 {
+		t.Errorf("code: got %d, want 21422", twilioErr.Code)
+	}
+}
+
+func TestErrorAuthFailure(t *testing.T) {
+	c := testClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		json.NewEncoder(w).Encode(map[string]any{
+			"code":    20003,
+			"message": "Authentication Error - invalid username",
+			"status":  401,
+		})
+	}))
+
+	_, err := c.SearchNumbers(context.Background(), "US")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+
+	var twilioErr *Error
+	if !errors.As(err, &twilioErr) {
+		t.Fatalf("expected *Error, got %T: %v", err, err)
+	}
+
+	if twilioErr.StatusCode != 401 {
+		t.Errorf("status: got %d, want 401", twilioErr.StatusCode)
+	}
+}
+
+func TestErrorReleaseNotFound(t *testing.T) {
+	c := testClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		json.NewEncoder(w).Encode(map[string]any{
+			"code":    20404,
+			"message": "The requested resource was not found",
+			"status":  404,
+		})
+	}))
+
+	err := c.ReleaseNumber(context.Background(), "PN_nonexistent")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+
+	var twilioErr *Error
+	if !errors.As(err, &twilioErr) {
+		t.Fatalf("expected *Error, got %T: %v", err, err)
+	}
+
+	if twilioErr.StatusCode != 404 {
+		t.Errorf("status: got %d, want 404", twilioErr.StatusCode)
+	}
+}
+
+func TestErrorNonJSONResponse(t *testing.T) {
+	c := testClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		w.Write([]byte("internal server error"))
+	}))
+
+	_, err := c.SearchNumbers(context.Background(), "US")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+
+	var twilioErr *Error
+	if !errors.As(err, &twilioErr) {
+		t.Fatalf("expected *Error, got %T: %v", err, err)
+	}
+
+	if twilioErr.StatusCode != 500 {
+		t.Errorf("status: got %d, want 500", twilioErr.StatusCode)
+	}
+	// should fall back to status text when JSON parsing fails
+	if twilioErr.Message != "Internal Server Error" {
+		t.Errorf("message: got %q, want %q", twilioErr.Message, "Internal Server Error")
+	}
+}
+
+func TestErrorMessageFormat(t *testing.T) {
+	tests := []struct {
+		name string
+		err  Error
+		want string
+	}{
+		{
+			name: "with code",
+			err:  Error{StatusCode: 400, Code: 21422, Message: "Phone number is not available"},
+			want: "twilio: Phone number is not available (code 21422, status 400)",
+		},
+		{
+			name: "without code",
+			err:  Error{StatusCode: 500, Message: "Internal Server Error"},
+			want: "twilio: Internal Server Error (status 500)",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.err.Error(); got != tt.want {
+				t.Errorf("Error(): got %q, want %q", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes #48

Spec: zarlcorp/core/.manager/specs/101-twilio-sms-client.md

Internal Twilio API client for provisioning phone numbers (UK/US) and reading SMS. SearchNumbers, BuyNumber, ReleaseNumber, ListMessages. Standard library only, all tests use httptest.