### PR TITLE
102: 2FA code extractor

### DIFF
--- a/internal/codes/extract.go
+++ b/internal/codes/extract.go
@@ -1,0 +1,306 @@
+// Package codes extracts 2FA verification codes from email and SMS message bodies.
+package codes
+
+import (
+	"regexp"
+	"sort"
+	"strings"
+	"unicode"
+)
+
+// Code represents a potential verification code found in text.
+type Code struct {
+	Value string // the code itself, e.g. "123456"
+	Type  string // "numeric", "alphanumeric"
+}
+
+// context keywords that indicate a nearby number is a verification code
+var keywords = []string{
+	"verification",
+	"code",
+	"otp",
+	"one-time",
+	"confirm",
+	"pin",
+	"security code",
+	"2fa",
+	"authenticate",
+	"verify",
+}
+
+// numeric codes: 4, 6, or 8 digits with word boundaries
+var numericRe = regexp.MustCompile(`\b(\d{4}|\d{6}|\d{8})\b`)
+
+// alphanumeric codes: 6 chars mixing letters and digits (e.g. A1B2C3)
+var alphanumericRe = regexp.MustCompile(`\b([A-Za-z0-9]{6})\b`)
+
+// patterns that indicate a number is not a code
+var (
+	priceRe     = regexp.MustCompile(`\$\d`)
+	urlRe       = regexp.MustCompile(`https?://\S+`)
+	emailRe     = regexp.MustCompile(`\S+@\S+\.\S+`)
+	phoneRe     = regexp.MustCompile(`\b\d{10,}\b`)
+	yearRe      = regexp.MustCompile(`\b(19|20)\d{2}\b`)
+	timestampRe = regexp.MustCompile(`\d{1,2}:\d{2}`)
+)
+
+// Extract returns all potential verification codes found in the text,
+// ordered by confidence (most likely first).
+func Extract(text string) []Code {
+	if text == "" {
+		return nil
+	}
+
+	// pre-clean: remove URLs and email addresses so embedded numbers
+	// don't get picked up
+	cleaned := urlRe.ReplaceAllString(text, " ")
+	cleaned = emailRe.ReplaceAllString(cleaned, " ")
+
+	lower := strings.ToLower(cleaned)
+
+	type candidate struct {
+		code       Code
+		confidence int
+	}
+
+	seen := make(map[string]bool)
+	var candidates []candidate
+
+	// extract numeric codes
+	for _, match := range numericRe.FindAllStringIndex(cleaned, -1) {
+		val := cleaned[match[0]:match[1]]
+
+		if seen[val] {
+			continue
+		}
+
+		if isFiltered(cleaned, lower, val, match[0], match[1]) {
+			continue
+		}
+
+		c := candidate{
+			code: Code{Value: val, Type: "numeric"},
+		}
+		c.confidence = score(lower, val, match[0], match[1])
+		seen[val] = true
+		candidates = append(candidates, c)
+	}
+
+	// extract alphanumeric codes (must contain both letters and digits)
+	for _, match := range alphanumericRe.FindAllStringIndex(cleaned, -1) {
+		val := cleaned[match[0]:match[1]]
+
+		if seen[val] {
+			continue
+		}
+
+		if !hasMixedAlphaDigit(val) {
+			continue
+		}
+
+		// skip if it looks like a common word
+		if isCommonWord(val) {
+			continue
+		}
+
+		c := candidate{
+			code: Code{Value: val, Type: "alphanumeric"},
+		}
+		c.confidence = score(lower, val, match[0], match[1])
+		seen[val] = true
+		candidates = append(candidates, c)
+	}
+
+	if len(candidates) == 0 {
+		return nil
+	}
+
+	sort.Slice(candidates, func(i, j int) bool {
+		return candidates[i].confidence > candidates[j].confidence
+	})
+
+	result := make([]Code, len(candidates))
+	for i, c := range candidates {
+		result[i] = c.code
+	}
+	return result
+}
+
+// isFiltered returns true if the numeric value at the given position should
+// be excluded (years, phone numbers, prices, timestamps).
+func isFiltered(text, lower, val string, start, end int) bool {
+	digits := len(val)
+
+	// phone numbers: 10+ digits already handled by the regex only matching
+	// 4, 6, or 8 — but check surrounding context for phone patterns
+	if digits >= 4 {
+		// check if preceded by a price symbol
+		if start > 0 && text[start-1] == '$' {
+			return true
+		}
+		// check wider context for price pattern
+		if start >= 1 {
+			prefix := text[max(0, start-2):start]
+			if strings.Contains(prefix, "$") {
+				return true
+			}
+		}
+	}
+
+	// filter years: 4-digit numbers matching common year patterns
+	if digits == 4 && yearRe.MatchString(val) {
+		ctx := surroundingContext(lower, start, end, 30)
+		yearWords := []string{"copyright", "(c)", "year", "since", "est.", "founded"}
+		for _, w := range yearWords {
+			if strings.Contains(ctx, w) {
+				return true
+			}
+		}
+		// also filter if it looks like a standalone year with no code keywords
+		if !hasKeywordNearby(lower, start, end, 60) {
+			return true
+		}
+	}
+
+	// filter timestamps like 12:34
+	if digits == 4 {
+		if end < len(text) && text[end] == ':' {
+			return true
+		}
+		if start > 0 && text[start-1] == ':' {
+			return true
+		}
+	}
+
+	// filter if part of a longer number sequence (phone-like)
+	if start > 0 && unicode.IsDigit(rune(text[start-1])) {
+		return true
+	}
+	if end < len(text) && unicode.IsDigit(rune(text[end])) {
+		return true
+	}
+
+	// filter decimal numbers (prices like 123.45)
+	if end < len(text) && text[end] == '.' {
+		if end+1 < len(text) && unicode.IsDigit(rune(text[end+1])) {
+			return true
+		}
+	}
+	if start > 0 && text[start-1] == '.' {
+		if start >= 2 && unicode.IsDigit(rune(text[start-2])) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// score assigns a confidence value to a candidate code based on context.
+func score(lower, val string, start, end int) int {
+	s := 0
+
+	digits := 0
+	for _, r := range val {
+		if unicode.IsDigit(r) {
+			digits++
+		}
+	}
+
+	// 6-digit numeric codes are the most common 2FA format
+	if digits == 6 && len(val) == 6 {
+		s += 30
+	} else if digits == 8 && len(val) == 8 {
+		s += 20
+	} else if digits == 4 && len(val) == 4 {
+		s += 15
+	}
+
+	// alphanumeric codes are less common
+	if len(val) == 6 && digits < 6 {
+		s += 10
+	}
+
+	// keyword proximity boost
+	if hasKeywordNearby(lower, start, end, 60) {
+		s += 50
+	}
+
+	// structural clues: code follows "is", ":", or "-"
+	prefix := surroundingContext(lower, start, start, 10)
+	prefix = strings.TrimRight(prefix, " ")
+	if strings.HasSuffix(prefix, ":") || strings.HasSuffix(prefix, "is") || strings.HasSuffix(prefix, "-") {
+		s += 20
+	}
+
+	// code on its own line or surrounded by whitespace
+	if isIsolated(lower, start, end) {
+		s += 10
+	}
+
+	return s
+}
+
+// hasKeywordNearby checks if any verification-related keyword appears
+// within radius characters of the code position.
+func hasKeywordNearby(lower string, start, end, radius int) bool {
+	ctx := surroundingContext(lower, start, end, radius)
+	for _, kw := range keywords {
+		if strings.Contains(ctx, kw) {
+			return true
+		}
+	}
+	return false
+}
+
+// surroundingContext returns the text within radius chars around [start, end).
+func surroundingContext(text string, start, end, radius int) string {
+	lo := start - radius
+	if lo < 0 {
+		lo = 0
+	}
+	hi := end + radius
+	if hi > len(text) {
+		hi = len(text)
+	}
+	return text[lo:hi]
+}
+
+// isIsolated checks if the code is surrounded by whitespace or line boundaries.
+func isIsolated(text string, start, end int) bool {
+	before := start == 0 || text[start-1] == '\n' || text[start-1] == ' ' || text[start-1] == '\t'
+	after := end >= len(text) || text[end] == '\n' || text[end] == ' ' || text[end] == '\t'
+	return before && after
+}
+
+// hasMixedAlphaDigit returns true if s contains both letters and digits.
+func hasMixedAlphaDigit(s string) bool {
+	hasLetter := false
+	hasDigit := false
+	for _, r := range s {
+		if unicode.IsLetter(r) {
+			hasLetter = true
+		}
+		if unicode.IsDigit(r) {
+			hasDigit = true
+		}
+		if hasLetter && hasDigit {
+			return true
+		}
+	}
+	return false
+}
+
+// isCommonWord filters out 6-char strings that look like normal words
+// rather than verification codes.
+func isCommonWord(s string) bool {
+	lower := strings.ToLower(s)
+	// if it's all letters, it's probably a word not a code
+	allLetters := true
+	for _, r := range lower {
+		if !unicode.IsLetter(r) {
+			allLetters = false
+			break
+		}
+	}
+	return allLetters
+}

--- a/internal/codes/extract_test.go
+++ b/internal/codes/extract_test.go
@@ -1,0 +1,260 @@
+package codes
+
+import (
+	"testing"
+)
+
+func TestExtractCommonFormats(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  Code
+	}{
+		{
+			name:  "code is after text",
+			input: "Your verification code is 123456",
+			want:  Code{Value: "123456", Type: "numeric"},
+		},
+		{
+			name:  "code before text",
+			input: "123456 is your code",
+			want:  Code{Value: "123456", Type: "numeric"},
+		},
+		{
+			name:  "code after colon",
+			input: "Code: 123456",
+			want:  Code{Value: "123456", Type: "numeric"},
+		},
+		{
+			name:  "4 digit OTP",
+			input: "Your OTP: 1234",
+			want:  Code{Value: "1234", Type: "numeric"},
+		},
+		{
+			name:  "8 digit verification",
+			input: "Use 12345678 to verify",
+			want:  Code{Value: "12345678", Type: "numeric"},
+		},
+		{
+			name:  "alphanumeric confirmation",
+			input: "Enter A1B2C3 to confirm",
+			want:  Code{Value: "A1B2C3", Type: "alphanumeric"},
+		},
+		{
+			name:  "code after dash",
+			input: "Security code - 567890",
+			want:  Code{Value: "567890", Type: "numeric"},
+		},
+		{
+			name:  "code with is keyword",
+			input: "Your one-time code is 998877",
+			want:  Code{Value: "998877", Type: "numeric"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			codes := Extract(tt.input)
+			if len(codes) == 0 {
+				t.Fatalf("expected at least one code, got none")
+			}
+			got := codes[0]
+			if got.Value != tt.want.Value {
+				t.Errorf("value: got %q, want %q", got.Value, tt.want.Value)
+			}
+			if got.Type != tt.want.Type {
+				t.Errorf("type: got %q, want %q", got.Type, tt.want.Type)
+			}
+		})
+	}
+}
+
+func TestExtractFiltersCopyright(t *testing.T) {
+	codes := Extract("Copyright 2025 Acme Inc. All rights reserved.")
+	if len(codes) != 0 {
+		t.Errorf("expected no codes, got %v", codes)
+	}
+}
+
+func TestExtractFiltersPhoneNumbers(t *testing.T) {
+	codes := Extract("Call us at 1234567890 for support")
+	for _, c := range codes {
+		if c.Value == "1234567890" {
+			t.Error("extracted phone number as code")
+		}
+	}
+}
+
+func TestExtractFiltersPrice(t *testing.T) {
+	codes := Extract("Total: $123.45 due today")
+	for _, c := range codes {
+		if c.Value == "123" || c.Value == "12345" {
+			t.Errorf("extracted price component %q as code", c.Value)
+		}
+	}
+}
+
+func TestExtractFiltersTimestamp(t *testing.T) {
+	codes := Extract("Meeting at 10:30 in conference room")
+	for _, c := range codes {
+		if c.Value == "1030" {
+			t.Errorf("extracted timestamp as code")
+		}
+	}
+}
+
+func TestExtractFiltersYear(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+	}{
+		{"standalone year", "Founded in 2024, we serve customers worldwide"},
+		{"year with copyright", "(c) 2026 All rights reserved"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			codes := Extract(tt.input)
+			if len(codes) != 0 {
+				t.Errorf("expected no codes, got %v", codes)
+			}
+		})
+	}
+}
+
+func TestExtractFiltersURL(t *testing.T) {
+	codes := Extract("Visit https://example.com/verify/123456 for details")
+	for _, c := range codes {
+		if c.Value == "123456" {
+			t.Error("extracted number from URL as code")
+		}
+	}
+}
+
+func TestExtractFiltersEmail(t *testing.T) {
+	codes := Extract("Contact user123456@example.com for help")
+	for _, c := range codes {
+		if c.Value == "123456" {
+			t.Error("extracted number from email as code")
+		}
+	}
+}
+
+func TestExtractMultipleCodesHighestConfidenceFirst(t *testing.T) {
+	text := "Your account number is 8765. Your verification code is 123456. Reference: 4321."
+	codes := Extract(text)
+	if len(codes) < 2 {
+		t.Fatalf("expected at least 2 codes, got %d", len(codes))
+	}
+	// 6-digit with keyword should be first
+	if codes[0].Value != "123456" {
+		t.Errorf("first code: got %q, want %q", codes[0].Value, "123456")
+	}
+}
+
+func TestExtractEmptyInput(t *testing.T) {
+	codes := Extract("")
+	if codes != nil {
+		t.Errorf("expected nil, got %v", codes)
+	}
+}
+
+func TestExtractNoMatch(t *testing.T) {
+	codes := Extract("Hello, this is a regular message with no codes.")
+	if len(codes) != 0 {
+		t.Errorf("expected no codes, got %v", codes)
+	}
+}
+
+func TestExtractReturnsNilNotEmpty(t *testing.T) {
+	codes := Extract("nothing here")
+	if codes != nil {
+		t.Error("expected nil for no matches")
+	}
+}
+
+func TestExtractRealWorldMessages(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "google",
+			input: "G-123456 is your Google verification code.",
+			want:  "123456",
+		},
+		{
+			name:  "aws",
+			input: "Your AWS verification code is: 456789",
+			want:  "456789",
+		},
+		{
+			name:  "slack",
+			input: "Your Slack confirmation code is: 987654",
+			want:  "987654",
+		},
+		{
+			name:  "stripe",
+			input: "Your Stripe verification code is 112233. Don't share this code with anyone.",
+			want:  "112233",
+		},
+		{
+			name:  "github",
+			input: "Your GitHub authentication code:\n\n654321\n\nThis code will expire in 10 minutes.",
+			want:  "654321",
+		},
+		{
+			name:  "generic sms",
+			input: "Your OTP is 7890. Valid for 5 min.",
+			want:  "7890",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			codes := Extract(tt.input)
+			if len(codes) == 0 {
+				t.Fatal("expected at least one code, got none")
+			}
+			if codes[0].Value != tt.want {
+				t.Errorf("got %q, want %q", codes[0].Value, tt.want)
+			}
+		})
+	}
+}
+
+func TestExtractSixDigitRanksAboveFourDigit(t *testing.T) {
+	text := "Your PIN is 1234 and your verification code is 567890"
+	codes := Extract(text)
+	if len(codes) < 2 {
+		t.Fatalf("expected at least 2 codes, got %d", len(codes))
+	}
+	if codes[0].Value != "567890" {
+		t.Errorf("expected 6-digit code first, got %q", codes[0].Value)
+	}
+}
+
+func TestExtractAlphanumericWithKeyword(t *testing.T) {
+	text := "Your verification code is X9Y8Z7"
+	codes := Extract(text)
+	if len(codes) == 0 {
+		t.Fatal("expected at least one code, got none")
+	}
+	if codes[0].Value != "X9Y8Z7" {
+		t.Errorf("got %q, want %q", codes[0].Value, "X9Y8Z7")
+	}
+	if codes[0].Type != "alphanumeric" {
+		t.Errorf("type: got %q, want %q", codes[0].Type, "alphanumeric")
+	}
+}
+
+func TestExtractDoesNotExtractPlainWords(t *testing.T) {
+	// "please" is 6 chars, all letters - should not be extracted
+	codes := Extract("please verify your account")
+	for _, c := range codes {
+		if c.Value == "please" {
+			t.Error("extracted plain word as code")
+		}
+	}
+}


### PR DESCRIPTION
Closes #49

Spec: zarlcorp/core/.manager/specs/102-2fa-code-extractor.md

Internal utility for extracting verification codes from message text. Supports 4/6/8-digit numeric and alphanumeric codes with confidence scoring, keyword detection, and filtering of false positives (years, phones, prices, URLs).