### PR TITLE
100: Gmail OAuth2 client

### DIFF
--- a/internal/gmail/auth.go
+++ b/internal/gmail/auth.go
@@ -1,0 +1,229 @@
+// Package gmail provides OAuth2 authentication and API access to Gmail.
+// it handles the browser-based consent flow and token refresh for TUI apps.
+package gmail
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"net"
+	"net/http"
+	"net/url"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+const (
+	authEndpoint        = "https://accounts.google.com/o/oauth2/v2/auth"
+	defaultTokenEndpoint = "https://oauth2.googleapis.com/token"
+	gmailScope          = "https://www.googleapis.com/auth/gmail.readonly"
+)
+
+// tokenEndpoint is a var so tests can point it at httptest servers.
+var tokenEndpoint = defaultTokenEndpoint
+
+// setTokenEndpoint overrides the token endpoint (for testing).
+func setTokenEndpoint(u string) { tokenEndpoint = u }
+
+// OAuthConfig holds Google OAuth2 client credentials.
+type OAuthConfig struct {
+	ClientID     string
+	ClientSecret string
+}
+
+// Token holds OAuth2 access and refresh tokens.
+type Token struct {
+	AccessToken  string    `json:"access_token"`
+	RefreshToken string    `json:"refresh_token"`
+	Expiry       time.Time `json:"expiry"`
+}
+
+// tokenResponse maps the JSON returned by Google's token endpoint.
+type tokenResponse struct {
+	AccessToken  string `json:"access_token"`
+	RefreshToken string `json:"refresh_token"`
+	ExpiresIn    int    `json:"expires_in"`
+	TokenType    string `json:"token_type"`
+}
+
+// Authenticate runs the OAuth2 authorization code flow.
+// it starts a temporary localhost server, opens the browser to Google's consent
+// screen, captures the callback, and exchanges the code for tokens.
+func Authenticate(ctx context.Context, cfg OAuthConfig) (*Token, error) {
+	state, err := randomState()
+	if err != nil {
+		return nil, fmt.Errorf("authenticate: generate state: %w", err)
+	}
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		return nil, fmt.Errorf("authenticate: listen: %w", err)
+	}
+	defer ln.Close()
+
+	port := ln.Addr().(*net.TCPAddr).Port
+	redirectURI := fmt.Sprintf("http://localhost:%d/callback", port)
+
+	authURL := buildAuthURL(cfg.ClientID, redirectURI, state)
+
+	// channel receives the auth code or an error from the callback handler
+	type result struct {
+		code string
+		err  error
+	}
+	ch := make(chan result, 1)
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/callback", func(w http.ResponseWriter, r *http.Request) {
+		if s := r.URL.Query().Get("state"); s != state {
+			ch <- result{err: fmt.Errorf("state mismatch: got %q", s)}
+			http.Error(w, "state mismatch", http.StatusBadRequest)
+			return
+		}
+
+		if errMsg := r.URL.Query().Get("error"); errMsg != "" {
+			ch <- result{err: fmt.Errorf("oauth error: %s", errMsg)}
+			http.Error(w, errMsg, http.StatusBadRequest)
+			return
+		}
+
+		code := r.URL.Query().Get("code")
+		if code == "" {
+			ch <- result{err: fmt.Errorf("no code in callback")}
+			http.Error(w, "missing code", http.StatusBadRequest)
+			return
+		}
+
+		fmt.Fprint(w, "authorization complete — you can close this tab.")
+		ch <- result{code: code}
+	})
+
+	srv := &http.Server{Handler: mux}
+	go srv.Serve(ln)
+	defer srv.Shutdown(context.Background())
+
+	if err := openBrowser(authURL); err != nil {
+		return nil, fmt.Errorf("authenticate: open browser: %w", err)
+	}
+
+	var code string
+	select {
+	case <-ctx.Done():
+		return nil, fmt.Errorf("authenticate: %w", ctx.Err())
+	case res := <-ch:
+		if res.err != nil {
+			return nil, fmt.Errorf("authenticate: %w", res.err)
+		}
+		code = res.code
+	}
+
+	return exchangeCode(ctx, cfg, code, redirectURI)
+}
+
+// RefreshToken exchanges a refresh token for a new access token.
+func RefreshToken(ctx context.Context, cfg OAuthConfig, refreshToken string) (*Token, error) {
+	data := url.Values{
+		"client_id":     {cfg.ClientID},
+		"client_secret": {cfg.ClientSecret},
+		"refresh_token": {refreshToken},
+		"grant_type":    {"refresh_token"},
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, tokenEndpoint, strings.NewReader(data.Encode()))
+	if err != nil {
+		return nil, fmt.Errorf("refresh token: build request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("refresh token: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("refresh token: status %d", resp.StatusCode)
+	}
+
+	var tr tokenResponse
+	if err := json.NewDecoder(resp.Body).Decode(&tr); err != nil {
+		return nil, fmt.Errorf("refresh token: decode response: %w", err)
+	}
+
+	tok := &Token{
+		AccessToken:  tr.AccessToken,
+		RefreshToken: refreshToken, // Google may not return a new refresh token
+		Expiry:       time.Now().Add(time.Duration(tr.ExpiresIn) * time.Second),
+	}
+	if tr.RefreshToken != "" {
+		tok.RefreshToken = tr.RefreshToken
+	}
+
+	return tok, nil
+}
+
+// buildAuthURL constructs the Google OAuth2 authorization URL.
+func buildAuthURL(clientID, redirectURI, state string) string {
+	v := url.Values{
+		"client_id":     {clientID},
+		"redirect_uri":  {redirectURI},
+		"response_type": {"code"},
+		"scope":         {gmailScope},
+		"access_type":   {"offline"},
+		"prompt":        {"consent"},
+		"state":         {state},
+	}
+	return authEndpoint + "?" + v.Encode()
+}
+
+func exchangeCode(ctx context.Context, cfg OAuthConfig, code, redirectURI string) (*Token, error) {
+	data := url.Values{
+		"client_id":     {cfg.ClientID},
+		"client_secret": {cfg.ClientSecret},
+		"code":          {code},
+		"grant_type":    {"authorization_code"},
+		"redirect_uri":  {redirectURI},
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, tokenEndpoint, strings.NewReader(data.Encode()))
+	if err != nil {
+		return nil, fmt.Errorf("exchange code: build request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("exchange code: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("exchange code: status %d", resp.StatusCode)
+	}
+
+	var tr tokenResponse
+	if err := json.NewDecoder(resp.Body).Decode(&tr); err != nil {
+		return nil, fmt.Errorf("exchange code: decode response: %w", err)
+	}
+
+	return &Token{
+		AccessToken:  tr.AccessToken,
+		RefreshToken: tr.RefreshToken,
+		Expiry:       time.Now().Add(time.Duration(tr.ExpiresIn) * time.Second),
+	}, nil
+}
+
+func randomState() (string, error) {
+	b := make([]byte, 16)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(b), nil
+}
+
+func openBrowser(url string) error {
+	return exec.Command("open", url).Start()
+}

--- a/internal/gmail/auth_test.go
+++ b/internal/gmail/auth_test.go
@@ -1,0 +1,191 @@
+package gmail
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+	"time"
+)
+
+func TestBuildAuthURL(t *testing.T) {
+	u := buildAuthURL("my-client-id", "http://localhost:9999/callback", "test-state")
+
+	parsed, err := url.Parse(u)
+	if err != nil {
+		t.Fatalf("parse URL: %v", err)
+	}
+
+	if got := parsed.Scheme + "://" + parsed.Host + parsed.Path; got != authEndpoint {
+		t.Errorf("endpoint = %q, want %q", got, authEndpoint)
+	}
+
+	tests := []struct {
+		param string
+		want  string
+	}{
+		{"client_id", "my-client-id"},
+		{"redirect_uri", "http://localhost:9999/callback"},
+		{"response_type", "code"},
+		{"scope", gmailScope},
+		{"access_type", "offline"},
+		{"prompt", "consent"},
+		{"state", "test-state"},
+	}
+
+	q := parsed.Query()
+	for _, tt := range tests {
+		if got := q.Get(tt.param); got != tt.want {
+			t.Errorf("param %q = %q, want %q", tt.param, got, tt.want)
+		}
+	}
+}
+
+func TestExchangeCode(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("method = %s, want POST", r.Method)
+		}
+
+		if err := r.ParseForm(); err != nil {
+			t.Fatalf("parse form: %v", err)
+		}
+
+		if got := r.Form.Get("grant_type"); got != "authorization_code" {
+			t.Errorf("grant_type = %q, want authorization_code", got)
+		}
+		if got := r.Form.Get("code"); got != "test-code" {
+			t.Errorf("code = %q, want test-code", got)
+		}
+		if got := r.Form.Get("client_id"); got != "cid" {
+			t.Errorf("client_id = %q, want cid", got)
+		}
+		if got := r.Form.Get("client_secret"); got != "csecret" {
+			t.Errorf("client_secret = %q, want csecret", got)
+		}
+
+		json.NewEncoder(w).Encode(tokenResponse{
+			AccessToken:  "access-123",
+			RefreshToken: "refresh-456",
+			ExpiresIn:    3600,
+			TokenType:    "Bearer",
+		})
+	}))
+	defer srv.Close()
+
+	// temporarily override the token endpoint
+	origEndpoint := tokenEndpoint
+	defer func() { setTokenEndpoint(origEndpoint) }()
+	setTokenEndpoint(srv.URL)
+
+	tok, err := exchangeCode(context.Background(), OAuthConfig{
+		ClientID:     "cid",
+		ClientSecret: "csecret",
+	}, "test-code", "http://localhost:9999/callback")
+	if err != nil {
+		t.Fatalf("exchangeCode: %v", err)
+	}
+
+	if tok.AccessToken != "access-123" {
+		t.Errorf("access token = %q, want access-123", tok.AccessToken)
+	}
+	if tok.RefreshToken != "refresh-456" {
+		t.Errorf("refresh token = %q, want refresh-456", tok.RefreshToken)
+	}
+	if tok.Expiry.Before(time.Now()) {
+		t.Errorf("expiry %v is in the past", tok.Expiry)
+	}
+}
+
+func TestRefreshToken(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("method = %s, want POST", r.Method)
+		}
+
+		if err := r.ParseForm(); err != nil {
+			t.Fatalf("parse form: %v", err)
+		}
+
+		if got := r.Form.Get("grant_type"); got != "refresh_token" {
+			t.Errorf("grant_type = %q, want refresh_token", got)
+		}
+		if got := r.Form.Get("refresh_token"); got != "old-refresh" {
+			t.Errorf("refresh_token = %q, want old-refresh", got)
+		}
+
+		json.NewEncoder(w).Encode(tokenResponse{
+			AccessToken: "new-access",
+			ExpiresIn:   7200,
+		})
+	}))
+	defer srv.Close()
+
+	origEndpoint := tokenEndpoint
+	defer func() { setTokenEndpoint(origEndpoint) }()
+	setTokenEndpoint(srv.URL)
+
+	tok, err := RefreshToken(context.Background(), OAuthConfig{
+		ClientID:     "cid",
+		ClientSecret: "csecret",
+	}, "old-refresh")
+	if err != nil {
+		t.Fatalf("RefreshToken: %v", err)
+	}
+
+	if tok.AccessToken != "new-access" {
+		t.Errorf("access token = %q, want new-access", tok.AccessToken)
+	}
+	// refresh token preserved when Google doesn't return a new one
+	if tok.RefreshToken != "old-refresh" {
+		t.Errorf("refresh token = %q, want old-refresh", tok.RefreshToken)
+	}
+}
+
+func TestRefreshTokenReturnsNewRefresh(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(tokenResponse{
+			AccessToken:  "new-access",
+			RefreshToken: "new-refresh",
+			ExpiresIn:    7200,
+		})
+	}))
+	defer srv.Close()
+
+	origEndpoint := tokenEndpoint
+	defer func() { setTokenEndpoint(origEndpoint) }()
+	setTokenEndpoint(srv.URL)
+
+	tok, err := RefreshToken(context.Background(), OAuthConfig{
+		ClientID:     "cid",
+		ClientSecret: "csecret",
+	}, "old-refresh")
+	if err != nil {
+		t.Fatalf("RefreshToken: %v", err)
+	}
+
+	if tok.RefreshToken != "new-refresh" {
+		t.Errorf("refresh token = %q, want new-refresh", tok.RefreshToken)
+	}
+}
+
+func TestRefreshTokenErrorStatus(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer srv.Close()
+
+	origEndpoint := tokenEndpoint
+	defer func() { setTokenEndpoint(origEndpoint) }()
+	setTokenEndpoint(srv.URL)
+
+	_, err := RefreshToken(context.Background(), OAuthConfig{
+		ClientID:     "cid",
+		ClientSecret: "csecret",
+	}, "bad-refresh")
+	if err == nil {
+		t.Fatal("expected error for 401 response")
+	}
+}

--- a/internal/gmail/client.go
+++ b/internal/gmail/client.go
@@ -1,0 +1,252 @@
+package gmail
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"mime"
+	"mime/multipart"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// apiBase is a var so tests can point it at httptest servers.
+var apiBase = "https://gmail.googleapis.com/gmail/v1/users/me"
+
+func setAPIBase(u string) { apiBase = u }
+
+// Message holds a parsed Gmail message.
+type Message struct {
+	ID      string
+	From    string
+	To      string
+	Subject string
+	Date    time.Time
+	Body    string // plain text content
+}
+
+// Client accesses the Gmail API using a bearer token.
+type Client struct {
+	accessToken string
+	httpClient  *http.Client
+}
+
+// NewClient creates a Gmail API client with the given access token.
+func NewClient(accessToken string) *Client {
+	return &Client{
+		accessToken: accessToken,
+		httpClient:  http.DefaultClient,
+	}
+}
+
+// listResponse maps the JSON from the messages.list endpoint.
+type listResponse struct {
+	Messages []struct {
+		ID string `json:"id"`
+	} `json:"messages"`
+}
+
+// apiMessage maps the JSON from the messages.get endpoint.
+type apiMessage struct {
+	ID      string `json:"id"`
+	Snippet string `json:"snippet"`
+	Payload struct {
+		MimeType string `json:"mimeType"`
+		Headers  []struct {
+			Name  string `json:"name"`
+			Value string `json:"value"`
+		} `json:"headers"`
+		Body struct {
+			Data string `json:"data"`
+		} `json:"body"`
+		Parts []apiPart `json:"parts"`
+	} `json:"payload"`
+}
+
+// apiPart maps a MIME part in the Gmail API response.
+type apiPart struct {
+	MimeType string `json:"mimeType"`
+	Body     struct {
+		Data string `json:"data"`
+	} `json:"body"`
+	Parts []apiPart `json:"parts"`
+}
+
+// ListMessages returns message IDs matching a Gmail search query.
+func (c *Client) ListMessages(ctx context.Context, query string, maxResults int) ([]Message, error) {
+	u := fmt.Sprintf("%s/messages?q=%s&maxResults=%d", apiBase, query, maxResults)
+
+	body, err := c.doGet(ctx, u)
+	if err != nil {
+		return nil, fmt.Errorf("list messages: %w", err)
+	}
+
+	var lr listResponse
+	if err := json.Unmarshal(body, &lr); err != nil {
+		return nil, fmt.Errorf("list messages: decode: %w", err)
+	}
+
+	msgs := make([]Message, len(lr.Messages))
+	for i, m := range lr.Messages {
+		msgs[i] = Message{ID: m.ID}
+	}
+
+	return msgs, nil
+}
+
+// GetMessage fetches a full message by ID, including headers and body text.
+func (c *Client) GetMessage(ctx context.Context, messageID string) (*Message, error) {
+	u := fmt.Sprintf("%s/messages/%s?format=full", apiBase, messageID)
+
+	body, err := c.doGet(ctx, u)
+	if err != nil {
+		return nil, fmt.Errorf("get message %s: %w", messageID, err)
+	}
+
+	var am apiMessage
+	if err := json.Unmarshal(body, &am); err != nil {
+		return nil, fmt.Errorf("get message %s: decode: %w", messageID, err)
+	}
+
+	return parseMessage(am)
+}
+
+func (c *Client) doGet(ctx context.Context, url string) ([]byte, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("build request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+c.accessToken)
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("status %d", resp.StatusCode)
+	}
+
+	// gmail messages are bounded in size, safe to read fully
+	b, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read body: %w", err)
+	}
+
+	return b, nil
+}
+
+func parseMessage(am apiMessage) (*Message, error) {
+	msg := &Message{ID: am.ID}
+
+	for _, h := range am.Payload.Headers {
+		switch strings.ToLower(h.Name) {
+		case "from":
+			msg.From = h.Value
+		case "to":
+			msg.To = h.Value
+		case "subject":
+			msg.Subject = h.Value
+		case "date":
+			msg.Date = parseDate(h.Value)
+		}
+	}
+
+	msg.Body = extractBody(am.Payload.MimeType, am.Payload.Body.Data, am.Payload.Parts)
+
+	return msg, nil
+}
+
+// extractBody finds the text/plain content from the message payload.
+// it handles single-part messages and recursively searches multipart messages.
+func extractBody(mimeType, bodyData string, parts []apiPart) string {
+	// single-part text/plain message
+	if strings.HasPrefix(mimeType, "text/plain") && bodyData != "" {
+		if decoded, err := decodeBase64URL(bodyData); err == nil {
+			return decoded
+		}
+	}
+
+	// search parts recursively for text/plain
+	for _, p := range parts {
+		if strings.HasPrefix(p.MimeType, "text/plain") && p.Body.Data != "" {
+			if decoded, err := decodeBase64URL(p.Body.Data); err == nil {
+				return decoded
+			}
+		}
+		// recurse into nested parts (e.g. multipart/alternative inside multipart/mixed)
+		if result := extractBody(p.MimeType, p.Body.Data, p.Parts); result != "" {
+			return result
+		}
+	}
+
+	return ""
+}
+
+// ParseMIMEBody extracts the text/plain part from a raw MIME multipart body.
+// this handles actual MIME content (as opposed to the Gmail API's pre-parsed parts).
+func ParseMIMEBody(contentType, body string) string {
+	mediaType, params, err := mime.ParseMediaType(contentType)
+	if err != nil {
+		return ""
+	}
+
+	if !strings.HasPrefix(mediaType, "multipart/") {
+		return ""
+	}
+
+	boundary := params["boundary"]
+	if boundary == "" {
+		return ""
+	}
+
+	r := multipart.NewReader(strings.NewReader(body), boundary)
+	for {
+		part, err := r.NextPart()
+		if err != nil {
+			break
+		}
+
+		ct := part.Header.Get("Content-Type")
+		if strings.HasPrefix(ct, "text/plain") || (ct == "" && strings.HasPrefix(mediaType, "multipart/")) {
+			b, err := io.ReadAll(part)
+			if err != nil {
+				continue
+			}
+			if text := string(b); text != "" {
+				return text
+			}
+		}
+	}
+
+	return ""
+}
+
+func decodeBase64URL(s string) (string, error) {
+	b, err := base64.URLEncoding.WithPadding(base64.NoPadding).DecodeString(s)
+	if err != nil {
+		return "", err
+	}
+	return string(b), nil
+}
+
+// parseDate tries common email date formats.
+func parseDate(s string) time.Time {
+	formats := []string{
+		time.RFC1123Z,
+		time.RFC1123,
+		"Mon, 2 Jan 2006 15:04:05 -0700",
+		"2 Jan 2006 15:04:05 -0700",
+		time.RFC3339,
+	}
+	for _, f := range formats {
+		if t, err := time.Parse(f, s); err == nil {
+			return t
+		}
+	}
+	return time.Time{}
+}

--- a/internal/gmail/client_test.go
+++ b/internal/gmail/client_test.go
@@ -1,0 +1,330 @@
+package gmail
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func b64(s string) string {
+	return base64.URLEncoding.WithPadding(base64.NoPadding).EncodeToString([]byte(s))
+}
+
+func TestListMessages(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("Authorization"); got != "Bearer test-token" {
+			t.Errorf("auth header = %q, want Bearer test-token", got)
+		}
+
+		if got := r.URL.Query().Get("q"); got != "to:alice@example.com" {
+			t.Errorf("query = %q, want to:alice@example.com", got)
+		}
+
+		json.NewEncoder(w).Encode(listResponse{
+			Messages: []struct {
+				ID string `json:"id"`
+			}{
+				{ID: "msg-1"},
+				{ID: "msg-2"},
+			},
+		})
+	}))
+	defer srv.Close()
+
+	c := NewClient("test-token")
+	c.httpClient = srv.Client()
+
+	// override apiBase by using a custom URL in the request
+	origBase := apiBase
+	defer func() { setAPIBase(origBase) }()
+	setAPIBase(srv.URL)
+
+	msgs, err := c.ListMessages(context.Background(), "to:alice@example.com", 10)
+	if err != nil {
+		t.Fatalf("ListMessages: %v", err)
+	}
+
+	if len(msgs) != 2 {
+		t.Fatalf("got %d messages, want 2", len(msgs))
+	}
+	if msgs[0].ID != "msg-1" {
+		t.Errorf("msgs[0].ID = %q, want msg-1", msgs[0].ID)
+	}
+	if msgs[1].ID != "msg-2" {
+		t.Errorf("msgs[1].ID = %q, want msg-2", msgs[1].ID)
+	}
+}
+
+func TestListMessagesEmpty(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(listResponse{})
+	}))
+	defer srv.Close()
+
+	c := NewClient("test-token")
+	c.httpClient = srv.Client()
+
+	origBase := apiBase
+	defer func() { setAPIBase(origBase) }()
+	setAPIBase(srv.URL)
+
+	msgs, err := c.ListMessages(context.Background(), "to:nobody@example.com", 10)
+	if err != nil {
+		t.Fatalf("ListMessages: %v", err)
+	}
+
+	if len(msgs) != 0 {
+		t.Errorf("got %d messages, want 0", len(msgs))
+	}
+}
+
+func TestGetMessagePlainText(t *testing.T) {
+	bodyText := "Your verification code is 123456"
+
+	am := apiMessage{
+		ID: "msg-abc",
+	}
+	am.Payload.MimeType = "text/plain"
+	am.Payload.Headers = []struct {
+		Name  string `json:"name"`
+		Value string `json:"value"`
+	}{
+		{Name: "From", Value: "noreply@example.com"},
+		{Name: "To", Value: "alice@example.com"},
+		{Name: "Subject", Value: "Your 2FA Code"},
+		{Name: "Date", Value: "Mon, 16 Feb 2026 10:00:00 -0500"},
+	}
+	am.Payload.Body.Data = b64(bodyText)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(am)
+	}))
+	defer srv.Close()
+
+	c := NewClient("test-token")
+	c.httpClient = srv.Client()
+
+	origBase := apiBase
+	defer func() { setAPIBase(origBase) }()
+	setAPIBase(srv.URL)
+
+	msg, err := c.GetMessage(context.Background(), "msg-abc")
+	if err != nil {
+		t.Fatalf("GetMessage: %v", err)
+	}
+
+	if msg.ID != "msg-abc" {
+		t.Errorf("ID = %q, want msg-abc", msg.ID)
+	}
+	if msg.From != "noreply@example.com" {
+		t.Errorf("From = %q, want noreply@example.com", msg.From)
+	}
+	if msg.To != "alice@example.com" {
+		t.Errorf("To = %q, want alice@example.com", msg.To)
+	}
+	if msg.Subject != "Your 2FA Code" {
+		t.Errorf("Subject = %q, want Your 2FA Code", msg.Subject)
+	}
+	if msg.Body != bodyText {
+		t.Errorf("Body = %q, want %q", msg.Body, bodyText)
+	}
+	if msg.Date.IsZero() {
+		t.Error("Date is zero")
+	}
+}
+
+func TestGetMessageMultipart(t *testing.T) {
+	plainBody := "plain text part"
+	htmlBody := "<p>html part</p>"
+
+	am := apiMessage{
+		ID: "msg-multi",
+	}
+	am.Payload.MimeType = "multipart/alternative"
+	am.Payload.Headers = []struct {
+		Name  string `json:"name"`
+		Value string `json:"value"`
+	}{
+		{Name: "Subject", Value: "Multipart Test"},
+	}
+	am.Payload.Parts = []apiPart{
+		{
+			MimeType: "text/plain",
+			Body: struct {
+				Data string `json:"data"`
+			}{Data: b64(plainBody)},
+		},
+		{
+			MimeType: "text/html",
+			Body: struct {
+				Data string `json:"data"`
+			}{Data: b64(htmlBody)},
+		},
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(am)
+	}))
+	defer srv.Close()
+
+	c := NewClient("test-token")
+	c.httpClient = srv.Client()
+
+	origBase := apiBase
+	defer func() { setAPIBase(origBase) }()
+	setAPIBase(srv.URL)
+
+	msg, err := c.GetMessage(context.Background(), "msg-multi")
+	if err != nil {
+		t.Fatalf("GetMessage: %v", err)
+	}
+
+	if msg.Body != plainBody {
+		t.Errorf("Body = %q, want %q", msg.Body, plainBody)
+	}
+}
+
+func TestGetMessageNestedMultipart(t *testing.T) {
+	plainBody := "nested plain text"
+
+	am := apiMessage{
+		ID: "msg-nested",
+	}
+	am.Payload.MimeType = "multipart/mixed"
+	am.Payload.Parts = []apiPart{
+		{
+			MimeType: "multipart/alternative",
+			Parts: []apiPart{
+				{
+					MimeType: "text/plain",
+					Body: struct {
+						Data string `json:"data"`
+					}{Data: b64(plainBody)},
+				},
+				{
+					MimeType: "text/html",
+					Body: struct {
+						Data string `json:"data"`
+					}{Data: b64("<p>nested html</p>")},
+				},
+			},
+		},
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(am)
+	}))
+	defer srv.Close()
+
+	c := NewClient("test-token")
+	c.httpClient = srv.Client()
+
+	origBase := apiBase
+	defer func() { setAPIBase(origBase) }()
+	setAPIBase(srv.URL)
+
+	msg, err := c.GetMessage(context.Background(), "msg-nested")
+	if err != nil {
+		t.Fatalf("GetMessage: %v", err)
+	}
+
+	if msg.Body != plainBody {
+		t.Errorf("Body = %q, want %q", msg.Body, plainBody)
+	}
+}
+
+func TestGetMessageErrorStatus(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	c := NewClient("test-token")
+	c.httpClient = srv.Client()
+
+	origBase := apiBase
+	defer func() { setAPIBase(origBase) }()
+	setAPIBase(srv.URL)
+
+	_, err := c.GetMessage(context.Background(), "not-found")
+	if err == nil {
+		t.Fatal("expected error for 404 response")
+	}
+}
+
+func TestParseMIMEBody(t *testing.T) {
+	boundary := "boundary123"
+	body := "--" + boundary + "\r\n" +
+		"Content-Type: text/plain; charset=utf-8\r\n" +
+		"\r\n" +
+		"Hello from plain text\r\n" +
+		"--" + boundary + "\r\n" +
+		"Content-Type: text/html; charset=utf-8\r\n" +
+		"\r\n" +
+		"<p>Hello from HTML</p>\r\n" +
+		"--" + boundary + "--\r\n"
+
+	contentType := "multipart/alternative; boundary=" + boundary
+
+	result := ParseMIMEBody(contentType, body)
+	if result != "Hello from plain text" {
+		t.Errorf("ParseMIMEBody = %q, want %q", result, "Hello from plain text")
+	}
+}
+
+func TestParseMIMEBodyNoPlainText(t *testing.T) {
+	boundary := "boundary456"
+	body := "--" + boundary + "\r\n" +
+		"Content-Type: text/html; charset=utf-8\r\n" +
+		"\r\n" +
+		"<p>Only HTML</p>\r\n" +
+		"--" + boundary + "--\r\n"
+
+	contentType := "multipart/alternative; boundary=" + boundary
+
+	result := ParseMIMEBody(contentType, body)
+	if result != "" {
+		t.Errorf("ParseMIMEBody = %q, want empty string", result)
+	}
+}
+
+func TestParseMIMEBodyInvalidContentType(t *testing.T) {
+	result := ParseMIMEBody("text/plain", "just text")
+	if result != "" {
+		t.Errorf("ParseMIMEBody = %q, want empty for non-multipart", result)
+	}
+}
+
+func TestParseDate(t *testing.T) {
+	tests := []struct {
+		input string
+		year  int
+		month int
+		day   int
+	}{
+		{"Mon, 16 Feb 2026 10:00:00 -0500", 2026, 2, 16},
+		{"16 Feb 2026 10:00:00 -0500", 2026, 2, 16},
+		{"2026-02-16T10:00:00Z", 2026, 2, 16},
+	}
+
+	for _, tt := range tests {
+		d := parseDate(tt.input)
+		if d.IsZero() {
+			t.Errorf("parseDate(%q) returned zero time", tt.input)
+			continue
+		}
+		if d.Year() != tt.year || int(d.Month()) != tt.month || d.Day() != tt.day {
+			t.Errorf("parseDate(%q) = %v, want %d-%d-%d", tt.input, d, tt.year, tt.month, tt.day)
+		}
+	}
+}
+
+func TestParseDateUnknownFormat(t *testing.T) {
+	d := parseDate("not a date")
+	if !d.IsZero() {
+		t.Errorf("parseDate(unknown) = %v, want zero", d)
+	}
+}


### PR DESCRIPTION
Closes #47

Spec: zarlcorp/core/.manager/specs/100-gmail-oauth2-client.md

Internal Gmail client with full OAuth2 browser-based flow and email reading. Supports message listing, MIME multipart body extraction, and token refresh. Standard library only, all tests use httptest.