### PR TITLE
105: burn cascade with confirmation

### DIFF
--- a/internal/burn/burn.go
+++ b/internal/burn/burn.go
@@ -1,0 +1,251 @@
+// Package burn implements best-effort cascading deletion of persona resources.
+package burn
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/zarlcorp/zburn/internal/credential"
+	"github.com/zarlcorp/zburn/internal/identity"
+)
+
+// CredentialStore lists and deletes credentials.
+type CredentialStore interface {
+	List() ([]credential.Credential, error)
+	Delete(id string) error
+}
+
+// IdentityStore deletes identities.
+type IdentityStore interface {
+	Delete(id string) error
+}
+
+// EmailForwarder removes email forwarding rules.
+type EmailForwarder interface {
+	RemoveForwarding(ctx context.Context, domain, mailbox string) error
+}
+
+// PhoneReleaser releases provisioned phone numbers.
+type PhoneReleaser interface {
+	ReleaseNumber(ctx context.Context, numberSID string) error
+}
+
+// EmailConfig holds forwarding details for an identity.
+type EmailConfig struct {
+	Domain  string // e.g. "zburn.id"
+	Mailbox string // e.g. "swiftwolf1234"
+}
+
+// PhoneConfig holds provisioned phone details for an identity.
+type PhoneConfig struct {
+	NumberSID   string // Twilio SID for the provisioned number
+	PhoneNumber string // display number e.g. "+447123456789"
+}
+
+// Request describes what to burn.
+type Request struct {
+	Identity    identity.Identity
+	Credentials CredentialStore
+	Identities  IdentityStore
+	Email       *EmailConfig    // nil if no email forwarding configured
+	Forwarder   EmailForwarder  // nil if namecheap not configured
+	Phone       *PhoneConfig    // nil if no provisioned phone
+	Releaser    PhoneReleaser   // nil if twilio not configured
+}
+
+// StepStatus records the outcome of one cascade step.
+type StepStatus struct {
+	Description string
+	Err         error
+}
+
+// Result summarizes a completed burn.
+type Result struct {
+	Name             string
+	CredentialsCount int
+	Steps            []StepStatus
+}
+
+// HasErrors returns true if any step failed.
+func (r Result) HasErrors() bool {
+	for _, s := range r.Steps {
+		if s.Err != nil {
+			return true
+		}
+	}
+	return false
+}
+
+// Summary returns a human-readable summary of the burn result.
+func (r Result) Summary() string {
+	var b strings.Builder
+
+	if r.HasErrors() {
+		fmt.Fprintf(&b, "burned %s (with errors)", r.Name)
+	} else {
+		fmt.Fprintf(&b, "burned %s", r.Name)
+	}
+
+	for _, s := range r.Steps {
+		if s.Err != nil {
+			fmt.Fprintf(&b, "\n- %s: %v", s.Description, s.Err)
+		} else {
+			fmt.Fprintf(&b, "\n- %s", s.Description)
+		}
+	}
+
+	return b.String()
+}
+
+// Plan returns a list of human-readable descriptions of what will happen.
+// Used to populate the confirmation dialog.
+func Plan(req Request) []string {
+	var steps []string
+
+	// always list credentials
+	creds, err := countCredentials(req)
+	if err == nil && creds > 0 {
+		steps = append(steps, fmt.Sprintf("delete all credentials (%d)", creds))
+	} else if err == nil {
+		steps = append(steps, "delete all credentials (0)")
+	} else {
+		steps = append(steps, "delete all credentials")
+	}
+
+	if req.Forwarder != nil && req.Email != nil {
+		steps = append(steps, fmt.Sprintf("remove email forwarding for %s@%s", req.Email.Mailbox, req.Email.Domain))
+	}
+
+	if req.Releaser != nil && req.Phone != nil {
+		steps = append(steps, fmt.Sprintf("release phone number %s", req.Phone.PhoneNumber))
+	}
+
+	return steps
+}
+
+// Execute runs the burn cascade. It is best-effort: each step is attempted
+// regardless of whether previous steps failed. The identity itself is always
+// deleted last.
+func Execute(ctx context.Context, req Request) Result {
+	name := req.Identity.FirstName + " " + req.Identity.LastName
+	result := Result{Name: name}
+
+	// 1. delete credentials
+	result.deleteCredentials(req)
+
+	// 2. remove email forwarding
+	if req.Forwarder != nil && req.Email != nil {
+		result.removeEmail(ctx, req)
+	}
+
+	// 3. release phone number
+	if req.Releaser != nil && req.Phone != nil {
+		result.releasePhone(ctx, req)
+	}
+
+	// 4. delete identity
+	result.deleteIdentity(req)
+
+	return result
+}
+
+func (r *Result) deleteCredentials(req Request) {
+	creds, err := req.Credentials.List()
+	if err != nil {
+		r.Steps = append(r.Steps, StepStatus{
+			Description: "delete credentials",
+			Err:         fmt.Errorf("list credentials: %w", err),
+		})
+		return
+	}
+
+	var matching []credential.Credential
+	for _, c := range creds {
+		if c.IdentityID == req.Identity.ID {
+			matching = append(matching, c)
+		}
+	}
+
+	var errs []string
+	deleted := 0
+	for _, c := range matching {
+		if err := req.Credentials.Delete(c.ID); err != nil {
+			errs = append(errs, fmt.Sprintf("%s: %v", c.ID, err))
+			continue
+		}
+		deleted++
+	}
+
+	r.CredentialsCount = deleted
+
+	if len(errs) > 0 {
+		r.Steps = append(r.Steps, StepStatus{
+			Description: fmt.Sprintf("deleted %d/%d credentials", deleted, len(matching)),
+			Err:         fmt.Errorf("%s", strings.Join(errs, "; ")),
+		})
+		return
+	}
+
+	r.Steps = append(r.Steps, StepStatus{
+		Description: fmt.Sprintf("deleted %d credentials", deleted),
+	})
+}
+
+func (r *Result) removeEmail(ctx context.Context, req Request) {
+	addr := req.Email.Mailbox + "@" + req.Email.Domain
+	err := req.Forwarder.RemoveForwarding(ctx, req.Email.Domain, req.Email.Mailbox)
+	if err != nil {
+		r.Steps = append(r.Steps, StepStatus{
+			Description: fmt.Sprintf("email forwarding removal for %s", addr),
+			Err:         err,
+		})
+		return
+	}
+	r.Steps = append(r.Steps, StepStatus{
+		Description: fmt.Sprintf("removed email forwarding for %s", addr),
+	})
+}
+
+func (r *Result) releasePhone(ctx context.Context, req Request) {
+	err := req.Releaser.ReleaseNumber(ctx, req.Phone.NumberSID)
+	if err != nil {
+		r.Steps = append(r.Steps, StepStatus{
+			Description: fmt.Sprintf("release phone number %s", req.Phone.PhoneNumber),
+			Err:         err,
+		})
+		return
+	}
+	r.Steps = append(r.Steps, StepStatus{
+		Description: fmt.Sprintf("released phone number %s", req.Phone.PhoneNumber),
+	})
+}
+
+func (r *Result) deleteIdentity(req Request) {
+	err := req.Identities.Delete(req.Identity.ID)
+	if err != nil {
+		r.Steps = append(r.Steps, StepStatus{
+			Description: "delete identity",
+			Err:         err,
+		})
+		return
+	}
+	r.Steps = append(r.Steps, StepStatus{
+		Description: "deleted identity",
+	})
+}
+
+func countCredentials(req Request) (int, error) {
+	creds, err := req.Credentials.List()
+	if err != nil {
+		return 0, err
+	}
+
+	count := 0
+	for _, c := range creds {
+		if c.IdentityID == req.Identity.ID {
+			count++
+		}
+	}
+	return count, nil
+}

--- a/internal/burn/burn_test.go
+++ b/internal/burn/burn_test.go
@@ -1,0 +1,521 @@
+package burn
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/zarlcorp/zburn/internal/credential"
+	"github.com/zarlcorp/zburn/internal/identity"
+)
+
+// fakes
+
+type fakeCredentialStore struct {
+	creds   []credential.Credential
+	listErr error
+	delErr  map[string]error // per-ID delete errors
+	deleted []string
+}
+
+func (f *fakeCredentialStore) List() ([]credential.Credential, error) {
+	if f.listErr != nil {
+		return nil, f.listErr
+	}
+	return f.creds, nil
+}
+
+func (f *fakeCredentialStore) Delete(id string) error {
+	if err, ok := f.delErr[id]; ok {
+		return err
+	}
+	f.deleted = append(f.deleted, id)
+	return nil
+}
+
+type fakeIdentityStore struct {
+	deleted []string
+	delErr  error
+}
+
+func (f *fakeIdentityStore) Delete(id string) error {
+	if f.delErr != nil {
+		return f.delErr
+	}
+	f.deleted = append(f.deleted, id)
+	return nil
+}
+
+type fakeForwarder struct {
+	calls []forwarderCall
+	err   error
+}
+
+type forwarderCall struct {
+	domain, mailbox string
+}
+
+func (f *fakeForwarder) RemoveForwarding(_ context.Context, domain, mailbox string) error {
+	f.calls = append(f.calls, forwarderCall{domain, mailbox})
+	return f.err
+}
+
+type fakeReleaser struct {
+	calls []string
+	err   error
+}
+
+func (f *fakeReleaser) ReleaseNumber(_ context.Context, numberSID string) error {
+	f.calls = append(f.calls, numberSID)
+	return f.err
+}
+
+// helpers
+
+func testIdentity() identity.Identity {
+	return identity.Identity{
+		ID:        "id-001",
+		FirstName: "Jane",
+		LastName:  "Doe",
+		Email:     "swiftwolf1234@zburn.id",
+		Phone:     "(555) 123-4567",
+		CreatedAt: time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
+	}
+}
+
+func testCreds(identityID string, n int) []credential.Credential {
+	creds := make([]credential.Credential, n)
+	for i := range n {
+		creds[i] = credential.Credential{
+			ID:         fmt.Sprintf("cred-%03d", i),
+			IdentityID: identityID,
+			Label:      fmt.Sprintf("account %d", i),
+		}
+	}
+	return creds
+}
+
+// tests
+
+func TestExecuteFullCascade(t *testing.T) {
+	cs := &fakeCredentialStore{creds: testCreds("id-001", 3)}
+	is := &fakeIdentityStore{}
+	fwd := &fakeForwarder{}
+	rel := &fakeReleaser{}
+
+	req := Request{
+		Identity:    testIdentity(),
+		Credentials: cs,
+		Identities:  is,
+		Email:       &EmailConfig{Domain: "zburn.id", Mailbox: "swiftwolf1234"},
+		Forwarder:   fwd,
+		Phone:       &PhoneConfig{NumberSID: "PN_abc123", PhoneNumber: "+447123456789"},
+		Releaser:    rel,
+	}
+
+	result := Execute(context.Background(), req)
+
+	if result.HasErrors() {
+		t.Errorf("unexpected errors: %s", result.Summary())
+	}
+
+	if result.CredentialsCount != 3 {
+		t.Errorf("credentials deleted = %d, want 3", result.CredentialsCount)
+	}
+
+	if len(cs.deleted) != 3 {
+		t.Errorf("credential store deletes = %d, want 3", len(cs.deleted))
+	}
+
+	if len(fwd.calls) != 1 || fwd.calls[0].domain != "zburn.id" || fwd.calls[0].mailbox != "swiftwolf1234" {
+		t.Errorf("forwarder calls = %v, want [{zburn.id swiftwolf1234}]", fwd.calls)
+	}
+
+	if len(rel.calls) != 1 || rel.calls[0] != "PN_abc123" {
+		t.Errorf("releaser calls = %v, want [PN_abc123]", rel.calls)
+	}
+
+	if len(is.deleted) != 1 || is.deleted[0] != "id-001" {
+		t.Errorf("identity deletes = %v, want [id-001]", is.deleted)
+	}
+
+	if len(result.Steps) != 4 {
+		t.Errorf("steps = %d, want 4", len(result.Steps))
+	}
+}
+
+func TestExecuteNoEmailNoPhone(t *testing.T) {
+	cs := &fakeCredentialStore{creds: testCreds("id-001", 2)}
+	is := &fakeIdentityStore{}
+
+	req := Request{
+		Identity:    testIdentity(),
+		Credentials: cs,
+		Identities:  is,
+	}
+
+	result := Execute(context.Background(), req)
+
+	if result.HasErrors() {
+		t.Errorf("unexpected errors: %s", result.Summary())
+	}
+
+	// only credentials + identity steps
+	if len(result.Steps) != 2 {
+		t.Errorf("steps = %d, want 2", len(result.Steps))
+	}
+
+	if result.CredentialsCount != 2 {
+		t.Errorf("credentials deleted = %d, want 2", result.CredentialsCount)
+	}
+}
+
+func TestExecuteNoMatchingCredentials(t *testing.T) {
+	// credentials belong to a different identity
+	otherCreds := testCreds("id-999", 5)
+	cs := &fakeCredentialStore{creds: otherCreds}
+	is := &fakeIdentityStore{}
+
+	req := Request{
+		Identity:    testIdentity(),
+		Credentials: cs,
+		Identities:  is,
+	}
+
+	result := Execute(context.Background(), req)
+
+	if result.HasErrors() {
+		t.Errorf("unexpected errors: %s", result.Summary())
+	}
+
+	if result.CredentialsCount != 0 {
+		t.Errorf("credentials deleted = %d, want 0", result.CredentialsCount)
+	}
+}
+
+func TestExecuteEmailFailureContinues(t *testing.T) {
+	cs := &fakeCredentialStore{creds: testCreds("id-001", 1)}
+	is := &fakeIdentityStore{}
+	fwd := &fakeForwarder{err: fmt.Errorf("network timeout")}
+
+	req := Request{
+		Identity:    testIdentity(),
+		Credentials: cs,
+		Identities:  is,
+		Email:       &EmailConfig{Domain: "zburn.id", Mailbox: "swiftwolf1234"},
+		Forwarder:   fwd,
+	}
+
+	result := Execute(context.Background(), req)
+
+	if !result.HasErrors() {
+		t.Error("should have errors when email forwarding fails")
+	}
+
+	// credentials should still be deleted
+	if result.CredentialsCount != 1 {
+		t.Errorf("credentials deleted = %d, want 1", result.CredentialsCount)
+	}
+
+	// identity should still be deleted
+	if len(is.deleted) != 1 {
+		t.Errorf("identity deletes = %d, want 1", len(is.deleted))
+	}
+
+	// summary should mention the failure
+	if !strings.Contains(result.Summary(), "network timeout") {
+		t.Errorf("summary should contain error: %s", result.Summary())
+	}
+}
+
+func TestExecutePhoneFailureContinues(t *testing.T) {
+	cs := &fakeCredentialStore{}
+	is := &fakeIdentityStore{}
+	rel := &fakeReleaser{err: fmt.Errorf("twilio api error")}
+
+	req := Request{
+		Identity:    testIdentity(),
+		Credentials: cs,
+		Identities:  is,
+		Phone:       &PhoneConfig{NumberSID: "PN_abc", PhoneNumber: "+447123456789"},
+		Releaser:    rel,
+	}
+
+	result := Execute(context.Background(), req)
+
+	if !result.HasErrors() {
+		t.Error("should have errors when phone release fails")
+	}
+
+	// identity should still be deleted
+	if len(is.deleted) != 1 {
+		t.Errorf("identity deletes = %d, want 1", len(is.deleted))
+	}
+
+	if !strings.Contains(result.Summary(), "twilio api error") {
+		t.Errorf("summary should contain error: %s", result.Summary())
+	}
+}
+
+func TestExecuteCredentialListError(t *testing.T) {
+	cs := &fakeCredentialStore{listErr: fmt.Errorf("store corrupt")}
+	is := &fakeIdentityStore{}
+
+	req := Request{
+		Identity:    testIdentity(),
+		Credentials: cs,
+		Identities:  is,
+	}
+
+	result := Execute(context.Background(), req)
+
+	if !result.HasErrors() {
+		t.Error("should have errors when credential list fails")
+	}
+
+	// identity should still be deleted despite credential list failure
+	if len(is.deleted) != 1 {
+		t.Errorf("identity deletes = %d, want 1", len(is.deleted))
+	}
+}
+
+func TestExecutePartialCredentialDeleteError(t *testing.T) {
+	cs := &fakeCredentialStore{
+		creds:  testCreds("id-001", 3),
+		delErr: map[string]error{"cred-001": fmt.Errorf("locked")},
+	}
+	is := &fakeIdentityStore{}
+
+	req := Request{
+		Identity:    testIdentity(),
+		Credentials: cs,
+		Identities:  is,
+	}
+
+	result := Execute(context.Background(), req)
+
+	if !result.HasErrors() {
+		t.Error("should have errors when some credential deletes fail")
+	}
+
+	// 2 of 3 should succeed
+	if result.CredentialsCount != 2 {
+		t.Errorf("credentials deleted = %d, want 2", result.CredentialsCount)
+	}
+
+	if !strings.Contains(result.Summary(), "locked") {
+		t.Errorf("summary should mention locked error: %s", result.Summary())
+	}
+}
+
+func TestExecuteIdentityDeleteError(t *testing.T) {
+	cs := &fakeCredentialStore{}
+	is := &fakeIdentityStore{delErr: fmt.Errorf("permission denied")}
+
+	req := Request{
+		Identity:    testIdentity(),
+		Credentials: cs,
+		Identities:  is,
+	}
+
+	result := Execute(context.Background(), req)
+
+	if !result.HasErrors() {
+		t.Error("should have errors when identity delete fails")
+	}
+
+	if !strings.Contains(result.Summary(), "permission denied") {
+		t.Errorf("summary should mention error: %s", result.Summary())
+	}
+}
+
+func TestExecuteAllFailures(t *testing.T) {
+	cs := &fakeCredentialStore{listErr: fmt.Errorf("store error")}
+	is := &fakeIdentityStore{delErr: fmt.Errorf("identity error")}
+	fwd := &fakeForwarder{err: fmt.Errorf("email error")}
+	rel := &fakeReleaser{err: fmt.Errorf("phone error")}
+
+	req := Request{
+		Identity:    testIdentity(),
+		Credentials: cs,
+		Identities:  is,
+		Email:       &EmailConfig{Domain: "zburn.id", Mailbox: "test"},
+		Forwarder:   fwd,
+		Phone:       &PhoneConfig{NumberSID: "PN_x", PhoneNumber: "+441234"},
+		Releaser:    rel,
+	}
+
+	result := Execute(context.Background(), req)
+
+	if !result.HasErrors() {
+		t.Error("should have errors")
+	}
+
+	// all 4 steps should be attempted
+	if len(result.Steps) != 4 {
+		t.Errorf("steps = %d, want 4", len(result.Steps))
+	}
+
+	// every step should have an error
+	for i, s := range result.Steps {
+		if s.Err == nil {
+			t.Errorf("step %d (%s) should have error", i, s.Description)
+		}
+	}
+
+	summary := result.Summary()
+	if !strings.Contains(summary, "with errors") {
+		t.Errorf("summary should say 'with errors': %s", summary)
+	}
+}
+
+func TestPlanFullConfig(t *testing.T) {
+	cs := &fakeCredentialStore{creds: testCreds("id-001", 3)}
+	fwd := &fakeForwarder{}
+	rel := &fakeReleaser{}
+
+	req := Request{
+		Identity:    testIdentity(),
+		Credentials: cs,
+		Email:       &EmailConfig{Domain: "zburn.id", Mailbox: "swiftwolf1234"},
+		Forwarder:   fwd,
+		Phone:       &PhoneConfig{NumberSID: "PN_abc", PhoneNumber: "+447123456789"},
+		Releaser:    rel,
+	}
+
+	steps := Plan(req)
+
+	if len(steps) != 3 {
+		t.Fatalf("plan steps = %d, want 3", len(steps))
+	}
+
+	if !strings.Contains(steps[0], "credentials (3)") {
+		t.Errorf("step 0 = %q, want credentials count", steps[0])
+	}
+
+	if !strings.Contains(steps[1], "swiftwolf1234@zburn.id") {
+		t.Errorf("step 1 = %q, want email address", steps[1])
+	}
+
+	if !strings.Contains(steps[2], "+447123456789") {
+		t.Errorf("step 2 = %q, want phone number", steps[2])
+	}
+}
+
+func TestPlanNoExternal(t *testing.T) {
+	cs := &fakeCredentialStore{}
+
+	req := Request{
+		Identity:    testIdentity(),
+		Credentials: cs,
+	}
+
+	steps := Plan(req)
+
+	if len(steps) != 1 {
+		t.Fatalf("plan steps = %d, want 1", len(steps))
+	}
+
+	if !strings.Contains(steps[0], "credentials") {
+		t.Errorf("step 0 = %q, want credentials", steps[0])
+	}
+}
+
+func TestPlanCredentialListError(t *testing.T) {
+	cs := &fakeCredentialStore{listErr: fmt.Errorf("oops")}
+
+	req := Request{
+		Identity:    testIdentity(),
+		Credentials: cs,
+	}
+
+	steps := Plan(req)
+
+	// should still include credentials step, just without count
+	if len(steps) != 1 {
+		t.Fatalf("plan steps = %d, want 1", len(steps))
+	}
+
+	if !strings.Contains(steps[0], "credentials") {
+		t.Errorf("step 0 = %q, want credentials mention", steps[0])
+	}
+}
+
+func TestResultSummaryNoErrors(t *testing.T) {
+	r := Result{
+		Name:             "Jane Doe",
+		CredentialsCount: 3,
+		Steps: []StepStatus{
+			{Description: "deleted 3 credentials"},
+			{Description: "removed email forwarding for test@zburn.id"},
+			{Description: "deleted identity"},
+		},
+	}
+
+	s := r.Summary()
+	if strings.Contains(s, "with errors") {
+		t.Errorf("summary should not say 'with errors': %s", s)
+	}
+	if !strings.Contains(s, "burned Jane Doe") {
+		t.Errorf("summary should contain name: %s", s)
+	}
+}
+
+func TestResultSummaryWithErrors(t *testing.T) {
+	r := Result{
+		Name: "Jane Doe",
+		Steps: []StepStatus{
+			{Description: "deleted 0 credentials"},
+			{Description: "email forwarding removal for test@zburn.id", Err: fmt.Errorf("timeout")},
+			{Description: "deleted identity"},
+		},
+	}
+
+	s := r.Summary()
+	if !strings.Contains(s, "with errors") {
+		t.Errorf("summary should say 'with errors': %s", s)
+	}
+	if !strings.Contains(s, "timeout") {
+		t.Errorf("summary should contain error: %s", s)
+	}
+}
+
+func TestResultHasErrors(t *testing.T) {
+	tests := []struct {
+		name  string
+		steps []StepStatus
+		want  bool
+	}{
+		{
+			name: "no errors",
+			steps: []StepStatus{
+				{Description: "ok"},
+			},
+			want: false,
+		},
+		{
+			name: "with error",
+			steps: []StepStatus{
+				{Description: "ok"},
+				{Description: "bad", Err: fmt.Errorf("fail")},
+			},
+			want: true,
+		},
+		{
+			name:  "empty",
+			steps: nil,
+			want:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := Result{Steps: tt.steps}
+			if got := r.HasErrors(); got != tt.want {
+				t.Errorf("HasErrors() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/tui/burn.go
+++ b/internal/tui/burn.go
@@ -1,0 +1,165 @@
+package tui
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/charmbracelet/bubbles/key"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/zarlcorp/core/pkg/zstyle"
+	"github.com/zarlcorp/zburn/internal/burn"
+	"github.com/zarlcorp/zburn/internal/identity"
+)
+
+type burnPhase int
+
+const (
+	burnConfirm burnPhase = iota
+	burnRunning
+	burnDone
+)
+
+// burnIdentityMsg requests a burn cascade for a specific identity.
+type burnIdentityMsg struct {
+	identity identity.Identity
+}
+
+// burnResultMsg carries the result of a completed burn cascade.
+type burnResultMsg struct {
+	result burn.Result
+}
+
+// burnModel manages the burn confirmation dialog and result display.
+type burnModel struct {
+	identity identity.Identity
+	plan     []string
+	phase    burnPhase
+	result   burn.Result
+}
+
+func newBurnModel(id identity.Identity, plan []string) burnModel {
+	return burnModel{
+		identity: id,
+		plan:     plan,
+		phase:    burnConfirm,
+	}
+}
+
+func (m burnModel) Init() tea.Cmd {
+	return nil
+}
+
+func (m burnModel) Update(msg tea.Msg) (burnModel, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.KeyMsg:
+		return m.handleKey(msg)
+
+	case burnResultMsg:
+		m.result = msg.result
+		m.phase = burnDone
+		return m, clearFlashAfter3s()
+	}
+
+	return m, nil
+}
+
+func (m burnModel) handleKey(msg tea.KeyMsg) (burnModel, tea.Cmd) {
+	switch m.phase {
+	case burnConfirm:
+		return m.handleConfirmKey(msg)
+	case burnDone:
+		// any key returns to list
+		return m, func() tea.Msg { return navigateMsg{view: viewList} }
+	}
+	return m, nil
+}
+
+func (m burnModel) handleConfirmKey(msg tea.KeyMsg) (burnModel, tea.Cmd) {
+	// quit always works
+	if key.Matches(msg, zstyle.KeyQuit) {
+		return m, tea.Quit
+	}
+
+	switch msg.String() {
+	case "y":
+		m.phase = burnRunning
+		id := m.identity
+		return m, func() tea.Msg { return burnIdentityMsg{identity: id} }
+	default:
+		// any other key cancels, go back to detail
+		return m, func() tea.Msg { return navigateMsg{view: viewDetail} }
+	}
+}
+
+func (m burnModel) View() string {
+	switch m.phase {
+	case burnConfirm:
+		return m.viewConfirm()
+	case burnRunning:
+		return m.viewRunning()
+	case burnDone:
+		return m.viewDone()
+	}
+	return ""
+}
+
+func (m burnModel) viewConfirm() string {
+	name := m.identity.FirstName + " " + m.identity.LastName
+	title := zstyle.Title.Render("burn " + name + "?")
+	s := fmt.Sprintf("\n  %s\n\n", title)
+
+	s += "  " + zstyle.MutedText.Render("this will:") + "\n"
+	for _, step := range m.plan {
+		s += fmt.Sprintf("  %s %s\n", zstyle.StatusWarn.Render("-"), step)
+	}
+
+	s += "\n"
+	s += "  " + zstyle.StatusWarn.Render("this cannot be undone.") + " (y/n)\n"
+	s += "\n"
+
+	help := "y confirm  any key cancel  q quit"
+	s += "  " + zstyle.MutedText.Render(help) + "\n"
+	return s
+}
+
+func (m burnModel) viewRunning() string {
+	name := m.identity.FirstName + " " + m.identity.LastName
+	s := fmt.Sprintf("\n  %s\n\n", zstyle.Title.Render("burning "+name+"..."))
+	return s
+}
+
+func (m burnModel) viewDone() string {
+	var b strings.Builder
+
+	title := m.result.Summary()
+	lines := strings.Split(title, "\n")
+
+	// first line is the header
+	if m.result.HasErrors() {
+		b.WriteString(fmt.Sprintf("\n  %s\n\n", zstyle.StatusWarn.Render(lines[0])))
+	} else {
+		b.WriteString(fmt.Sprintf("\n  %s\n\n", zstyle.StatusOK.Render(lines[0])))
+	}
+
+	// remaining lines are step details
+	for _, line := range lines[1:] {
+		if strings.Contains(line, ":") && strings.Contains(line, "- ") {
+			// step with error — find the colon separating description from error
+			b.WriteString("  " + zstyle.StatusWarn.Render(line) + "\n")
+		} else {
+			b.WriteString("  " + line + "\n")
+		}
+	}
+
+	b.WriteString("\n")
+	b.WriteString("  " + zstyle.MutedText.Render("press any key to continue") + "\n")
+	return b.String()
+}
+
+// clearFlashAfter3s returns to list after 3 seconds.
+func clearFlashAfter3s() tea.Cmd {
+	return tea.Tick(3*time.Second, func(time.Time) tea.Msg {
+		return navigateMsg{view: viewList}
+	})
+}


### PR DESCRIPTION
Closes #52

Spec: zarlcorp/core/.manager/specs/105-burn-cascade.md

- Best-effort cascade deletion of credentials, email forwarding, phone numbers
- Confirmation dialog showing what will be burned
- Result reporting with mixed success/failure support
- Testable burn package with interfaces for external services