### PR TITLE
111: add ZBURN_PASSWORD env var, fix smoke test

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -29,7 +29,11 @@ func DataDir() string {
 }
 
 // ReadPassword prompts for a password on stderr and reads it without echo.
+// If ZBURN_PASSWORD is set, returns its value without prompting.
 func ReadPassword(prompt string, w io.Writer) (string, error) {
+	if p := os.Getenv("ZBURN_PASSWORD"); p != "" {
+		return p, nil
+	}
 	fmt.Fprint(w, prompt)
 	b, err := term.ReadPassword(int(syscall.Stdin))
 	fmt.Fprintln(w)
@@ -40,7 +44,11 @@ func ReadPassword(prompt string, w io.Writer) (string, error) {
 }
 
 // ReadNewPassword prompts for a new password with confirmation.
+// If ZBURN_PASSWORD is set, returns its value without prompting.
 func ReadNewPassword(w io.Writer) (string, error) {
+	if p := os.Getenv("ZBURN_PASSWORD"); p != "" {
+		return p, nil
+	}
 	pass, err := ReadPassword("master password: ", w)
 	if err != nil {
 		return "", err

--- a/test/smoke.sh
+++ b/test/smoke.sh
@@ -3,8 +3,7 @@
 # zburn pre-release smoke test
 #
 # Builds the binary, then exercises every CLI subcommand end-to-end.
-# Uses a Python pty wrapper to feed passwords through a real tty fd,
-# since term.ReadPassword requires an actual terminal.
+# Uses ZBURN_PASSWORD env var to supply passwords non-interactively.
 #
 # Usage:
 #   ./test/smoke.sh                     # build with default version ("dev")
@@ -41,81 +40,6 @@ fail() {
   if [[ -n "${2:-}" ]]; then
     printf "        %s\n" "$2"
   fi
-}
-
-# run_with_password executes a command with password(s) piped through a pty.
-# $1 = number of password prompts to answer (1 or 2)
-# remaining args = the command to run
-# stdout from the child is captured and echoed.
-run_with_password() {
-  local num_prompts="$1"
-  shift
-
-  local output
-  output=$(NUM_PROMPTS="$num_prompts" PASSWORD="$PASSWORD" python3 -c "
-import pty, os, sys, select, time
-
-def run():
-    password = os.environ['PASSWORD']
-    prompts_remaining = int(os.environ['NUM_PROMPTS'])
-
-    (child_pid, fd) = pty.fork()
-    if child_pid == 0:
-        os.execvp(sys.argv[1], sys.argv[1:])
-        os._exit(127)
-
-    output = b''
-    sent_all = (prompts_remaining <= 0)
-
-    while True:
-        try:
-            rlist, _, _ = select.select([fd], [], [], 5.0)
-        except (ValueError, OSError):
-            break
-        if not rlist:
-            break
-        try:
-            data = os.read(fd, 4096)
-        except OSError:
-            break
-        if not data:
-            break
-        output += data
-
-        if not sent_all and b'password:' in data.lower():
-            time.sleep(0.05)
-            os.write(fd, (password + '\n').encode())
-            prompts_remaining -= 1
-            if prompts_remaining <= 0:
-                sent_all = True
-
-    _, status = os.waitpid(child_pid, 0)
-    exit_code = os.waitstatus_to_exitcode(status)
-
-    # strip terminal noise: password prompts and echoed password
-    lines = output.decode('utf-8', errors='replace').splitlines()
-    clean = []
-    for line in lines:
-        s = line.strip().replace('\r', '')
-        if not s:
-            continue
-        low = s.lower()
-        if 'password:' in low and len(s) < 80:
-            continue
-        if s == password:
-            continue
-        clean.append(s)
-    sys.stdout.write('\n'.join(clean))
-    sys.exit(exit_code)
-
-run()
-" "$@" 2>/dev/null) || {
-    local rc=$?
-    echo "$output"
-    return $rc
-  }
-
-  echo "$output"
 }
 
 # --- setup ------------------------------------------------------------------
@@ -178,10 +102,10 @@ if $FIELDS_OK; then
   pass "identity --json contains all expected fields"
 fi
 
-# --- test 4: identity --json --save (first run = 2 password prompts) --------
+# --- test 4: identity --json --save (first run) ----------------------------
 
 printf "test: identity --json --save\n"
-SAVE_OUT=$(run_with_password 2 "$BINARY" identity --json --save) || {
+SAVE_OUT=$(ZBURN_PASSWORD="$PASSWORD" "$BINARY" identity --json --save 2>/dev/null) || {
   fail "identity --json --save exited non-zero"
   SAVE_OUT=""
 }
@@ -193,30 +117,7 @@ if [[ -n "$SAVE_OUT" ]]; then
     fail "store salt file not found" "ls: $(ls "$DATADIR/zburn/" 2>&1)"
   fi
 
-  # extract identity ID from the JSON in the output
-  SAVED_ID=$(echo "$SAVE_OUT" | python3 -c "
-import sys, json
-
-text = sys.stdin.read()
-# find the JSON object — output may have terminal noise around it
-depth = 0
-start = -1
-for i, ch in enumerate(text):
-    if ch == '{':
-        if depth == 0:
-            start = i
-        depth += 1
-    elif ch == '}':
-        depth -= 1
-        if depth == 0 and start >= 0:
-            try:
-                d = json.loads(text[start:i+1])
-                print(d['id'])
-                sys.exit(0)
-            except (json.JSONDecodeError, KeyError):
-                start = -1
-sys.exit(1)
-" 2>/dev/null) || SAVED_ID=""
+  SAVED_ID=$(echo "$SAVE_OUT" | python3 -c "import sys,json; print(json.load(sys.stdin)['id'])" 2>/dev/null) || SAVED_ID=""
 
   if [[ -n "$SAVED_ID" ]]; then
     pass "extracted saved identity ID: $SAVED_ID"
@@ -225,26 +126,16 @@ sys.exit(1)
   fi
 fi
 
-# --- test 5: list --json (subsequent run = 1 password prompt) ---------------
+# --- test 5: list --json ----------------------------------------------------
 
 printf "test: list --json\n"
-LIST_OUT=$(run_with_password 1 "$BINARY" list --json) || {
+LIST_OUT=$(ZBURN_PASSWORD="$PASSWORD" "$BINARY" list --json 2>/dev/null) || {
   fail "list --json exited non-zero"
   LIST_OUT=""
 }
 
 if [[ -n "$LIST_OUT" ]]; then
-  LIST_HAS_ID=$(echo "$LIST_OUT" | python3 -c "
-import sys, json
-
-text = sys.stdin.read()
-start = text.find('[')
-end = text.rfind(']')
-if start < 0 or end < 0:
-    sys.exit(1)
-arr = json.loads(text[start:end+1])
-print(' '.join(item['id'] for item in arr))
-" 2>/dev/null) || LIST_HAS_ID=""
+  LIST_HAS_ID=$(echo "$LIST_OUT" | python3 -c "import sys,json; print(' '.join(i['id'] for i in json.loads(sys.stdin.read())))" 2>/dev/null) || LIST_HAS_ID=""
 
   if [[ -n "${SAVED_ID:-}" ]] && echo "$LIST_HAS_ID" | grep -q "$SAVED_ID"; then
     pass "list --json contains saved identity $SAVED_ID"
@@ -257,7 +148,7 @@ fi
 
 if [[ -n "${SAVED_ID:-}" ]]; then
   printf "test: forget %s\n" "$SAVED_ID"
-  FORGET_OUT=$(run_with_password 1 "$BINARY" forget "$SAVED_ID") || {
+  FORGET_OUT=$(ZBURN_PASSWORD="$PASSWORD" "$BINARY" forget "$SAVED_ID" 2>/dev/null) || {
     fail "forget exited non-zero"
     FORGET_OUT=""
   }
@@ -274,9 +165,9 @@ fi
 
 # --- test 7: list --json (should be empty after forget) ---------------------
 
-printf "test: list --json (after forget)\n"
-LIST2_OUT=$(run_with_password 1 "$BINARY" list --json) || {
-  fail "list --json (after forget) exited non-zero"
+printf "test: list (after forget)\n"
+LIST2_OUT=$(ZBURN_PASSWORD="$PASSWORD" "$BINARY" list 2>/dev/null) || {
+  fail "list (after forget) exited non-zero"
   LIST2_OUT=""
 }
 


### PR DESCRIPTION
Fixes smoke test hanging at identity --json --save. Adds ZBURN_PASSWORD env var support to bypass interactive prompt, removes Python pty wrapper from smoke.sh.