### PR TITLE
116: simplify Namecheap settings to username + API key

### DIFF
--- a/internal/namecheap/ip.go
+++ b/internal/namecheap/ip.go
@@ -1,0 +1,33 @@
+package namecheap
+
+import (
+	"context"
+	"fmt"
+	"net"
+)
+
+// openDNSResolver is the address of OpenDNS's resolver1.
+const openDNSResolver = "208.67.222.222:53"
+
+// detectPublicIP resolves the caller's public IP via DNS.
+// It queries myip.opendns.com against resolver1.opendns.com.
+func detectPublicIP(ctx context.Context) (string, error) {
+	r := &net.Resolver{
+		PreferGo: true,
+		Dial: func(ctx context.Context, network, address string) (net.Conn, error) {
+			var d net.Dialer
+			return d.DialContext(ctx, "udp", openDNSResolver)
+		},
+	}
+
+	addrs, err := r.LookupHost(ctx, "myip.opendns.com")
+	if err != nil {
+		return "", fmt.Errorf("detect public ip: %w", err)
+	}
+
+	if len(addrs) == 0 {
+		return "", fmt.Errorf("detect public ip: no addresses returned")
+	}
+
+	return addrs[0], nil
+}

--- a/internal/tui/config.go
+++ b/internal/tui/config.go
@@ -14,13 +14,11 @@ type configEnvelope struct {
 	Data json.RawMessage `json:"data"`
 }
 
-// NamecheapSettings holds Namecheap credentials and associated domains.
+// NamecheapSettings holds Namecheap credentials and cached domain list.
 type NamecheapSettings struct {
-	APIUser  string   `json:"api_user"`
-	APIKey   string   `json:"api_key"`
-	Username string   `json:"username"`
-	ClientIP string   `json:"client_ip"`
-	Domains  []string `json:"domains"`
+	Username      string   `json:"username"`
+	APIKey        string   `json:"api_key"`
+	CachedDomains []string `json:"cached_domains"`
 }
 
 // GmailSettings holds Gmail OAuth2 credentials and tokens.
@@ -38,7 +36,7 @@ type TwilioSettings struct {
 }
 
 func (s NamecheapSettings) Configured() bool {
-	return s.APIKey != "" && s.APIUser != ""
+	return s.Username != "" && s.APIKey != ""
 }
 
 func (s GmailSettings) Configured() bool {
@@ -52,10 +50,8 @@ func (s TwilioSettings) Configured() bool {
 // NamecheapConfig converts settings to a namecheap.Config for API use.
 func (s NamecheapSettings) NamecheapConfig() namecheap.Config {
 	return namecheap.Config{
-		APIUser:  s.APIUser,
-		APIKey:   s.APIKey,
 		Username: s.Username,
-		ClientIP: s.ClientIP,
+		APIKey:   s.APIKey,
 	}
 }
 

--- a/internal/tui/integration_test.go
+++ b/internal/tui/integration_test.go
@@ -291,11 +291,9 @@ func TestIntegrationNamecheapSettingsPersist(t *testing.T) {
 	m := setupModel(t)
 
 	nc := NamecheapSettings{
-		APIUser:  "myuser",
-		APIKey:   "mykey",
-		Username: "myname",
-		ClientIP: "10.0.0.1",
-		Domains:  []string{"foo.com", "bar.io"},
+		Username:      "myuser",
+		APIKey:        "mykey",
+		CachedDomains: []string{"foo.com", "bar.io"},
 	}
 
 	// save namecheap settings
@@ -311,17 +309,17 @@ func TestIntegrationNamecheapSettingsPersist(t *testing.T) {
 	if !m.NamecheapConfigured() {
 		t.Error("namecheap should be configured after reload")
 	}
-	if m.ncConfig.APIUser != "myuser" {
-		t.Errorf("APIUser = %q, want %q", m.ncConfig.APIUser, "myuser")
+	if m.ncConfig.Username != "myuser" {
+		t.Errorf("Username = %q, want %q", m.ncConfig.Username, "myuser")
 	}
 	if m.ncConfig.APIKey != "mykey" {
 		t.Errorf("APIKey = %q, want %q", m.ncConfig.APIKey, "mykey")
 	}
-	if len(m.ncConfig.Domains) != 2 {
-		t.Fatalf("Domains = %d, want 2", len(m.ncConfig.Domains))
+	if len(m.ncConfig.CachedDomains) != 2 {
+		t.Fatalf("CachedDomains = %d, want 2", len(m.ncConfig.CachedDomains))
 	}
-	if m.ncConfig.Domains[0] != "foo.com" || m.ncConfig.Domains[1] != "bar.io" {
-		t.Errorf("Domains = %v, want [foo.com bar.io]", m.ncConfig.Domains)
+	if m.ncConfig.CachedDomains[0] != "foo.com" || m.ncConfig.CachedDomains[1] != "bar.io" {
+		t.Errorf("CachedDomains = %v, want [foo.com bar.io]", m.ncConfig.CachedDomains)
 	}
 }
 
@@ -434,7 +432,7 @@ func TestIntegrationFeatureGatingMatchesStoredState(t *testing.T) {
 
 	// configure namecheap only
 	m = processMsg(t, m, saveNamecheapMsg{settings: NamecheapSettings{
-		APIUser: "u", APIKey: "k",
+		Username: "u", APIKey: "k",
 	}})
 
 	if !m.NamecheapConfigured() {

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -553,7 +553,7 @@ func (m Model) handleSaveNamecheap(s NamecheapSettings) (tea.Model, tea.Cmd) {
 	}
 
 	m.ncConfig = s
-	m.settingsNamecheap.flash = "saved"
+	// flash is already set by the namecheap model's validate handler
 	return m, clearFlashAfter()
 }
 


### PR DESCRIPTION
Closes #70

Spec: zarlcorp/core/.manager/specs/116-simplify-namecheap-settings.md