### PR TITLE
119: fix domain cycle and remove quick email menu option

### DIFF
--- a/internal/tui/menu.go
+++ b/internal/tui/menu.go
@@ -13,7 +13,6 @@ type menuChoice int
 
 const (
 	menuGenerate menuChoice = iota
-	menuEmail
 	menuBrowse
 	menuSettings
 	menuQuit
@@ -21,7 +20,6 @@ const (
 
 var menuItems = []string{
 	"generate identity",
-	"generate email (quick)",
 	"browse saved identities",
 	"settings",
 	"quit",
@@ -37,9 +35,6 @@ type menuModel struct {
 type navigateMsg struct {
 	view viewID
 }
-
-// quickEmailMsg tells the root to generate and copy an email.
-type quickEmailMsg struct{}
 
 func newMenuModel(version string) menuModel {
 	return menuModel{version: version}
@@ -82,8 +77,6 @@ func (m menuModel) selectItem() tea.Cmd {
 	switch menuChoice(m.cursor) {
 	case menuGenerate:
 		return func() tea.Msg { return navigateMsg{view: viewGenerate} }
-	case menuEmail:
-		return func() tea.Msg { return quickEmailMsg{} }
 	case menuBrowse:
 		return func() tea.Msg { return navigateMsg{view: viewList} }
 	case menuSettings:

--- a/internal/tui/settings_test.go
+++ b/internal/tui/settings_test.go
@@ -833,7 +833,7 @@ func TestTwilioNavigation(t *testing.T) {
 
 func TestMenuSelectSettings(t *testing.T) {
 	m := newMenuModel("1.0")
-	m.cursor = 3 // settings
+	m.cursor = 2 // settings
 	_, cmd := m.Update(enterKey())
 	if cmd == nil {
 		t.Fatal("enter should produce command")

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -114,9 +114,6 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case navigateMsg:
 		return m.navigate(msg.view)
 
-	case quickEmailMsg:
-		return m.handleQuickEmail()
-
 	case saveIdentityMsg:
 		return m.handleSave(msg.identity)
 
@@ -371,28 +368,14 @@ func (m Model) loadList() (tea.Model, tea.Cmd) {
 	return m, nil
 }
 
-func (m Model) handleQuickEmail() (tea.Model, tea.Cmd) {
-	first, last := m.gen.Name()
-	email := m.gen.Email(first, last, "")
-	if err := copyToClipboard(email); err != nil {
-		// fall through to menu with no notification
-		return m, nil
-	}
-
-	// show a brief flash on menu
-	m.menu = newMenuModel(m.version)
-	return m, func() tea.Msg {
-		return flashMsg{}
-	}
-}
-
 func (m Model) handleCycleDomain() (tea.Model, tea.Cmd) {
 	if len(m.domains) <= 1 {
 		return m, nil
 	}
 	m.domainIdx = (m.domainIdx + 1) % len(m.domains)
 	domain := m.domains[m.domainIdx]
-	id := m.gen.Generate(domain)
+	id := m.generate.identity
+	id.Email = m.gen.Email(id.FirstName, id.LastName, domain)
 	m.generate = newGenerateModel(id, domain)
 	return m, nil
 }


### PR DESCRIPTION
Closes #24

## Changes
- Fix `handleCycleDomain` to only update the email field instead of regenerating the entire identity — name, phone, address, DOB all stay the same when cycling domains
- Remove `menuEmail` / `quickEmailMsg` / "generate email (quick)" menu option from TUI
- Update tests: rename `TestCycleDomainRegeneratesIdentity` → `TestCycleDomainKeepsIdentity`, fix menu cursor indices

Spec: zarlcorp/core/.manager/specs/119-fix-domain-cycle-remove-quick-email.md