### PR TITLE
121: redesign identity list

### DIFF
--- a/internal/tui/list.go
+++ b/internal/tui/list.go
@@ -12,6 +12,7 @@ import (
 // listModel displays saved identities in a scrollable list.
 type listModel struct {
 	identities []identity.Identity
+	credCounts map[string]int
 	cursor     int
 	flash      string
 }
@@ -123,14 +124,14 @@ func (m listModel) View() string {
 		return s
 	}
 
-	// header
-	header := fmt.Sprintf("  %-10s %-20s %-30s %s", "id", "name", "email", "created")
-	s += zstyle.Subtitle.Render(header) + "\n"
-
 	for i, id := range m.identities {
-		name := id.FirstName + " " + id.LastName
-		line := fmt.Sprintf("  %-10s %-20s %-30s %s",
-			id.ID, truncate(name, 18), truncate(id.Email, 28), id.CreatedAt.Format("2006-01-02"))
+		name := truncate(id.FirstName+" "+id.LastName, 20)
+		email := truncate(id.Email, 30)
+		line := fmt.Sprintf("  %-20s %-30s", name, email)
+
+		if n := m.credCounts[id.ID]; n > 0 {
+			line += "  " + zstyle.MutedText.Render(fmt.Sprintf("(%d)", n))
+		}
 
 		if i == m.cursor {
 			s += zstyle.Highlight.Render("> "+line) + "\n"

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -364,8 +364,24 @@ func (m Model) loadList() (tea.Model, tea.Cmd) {
 	})
 
 	m.list = newListModel(ids)
+	m.list.credCounts = m.bulkCredCounts()
 	m.active = viewList
 	return m, nil
+}
+
+func (m Model) bulkCredCounts() map[string]int {
+	if m.credentials == nil {
+		return nil
+	}
+	all, err := m.credentials.List()
+	if err != nil {
+		return nil
+	}
+	counts := make(map[string]int)
+	for _, c := range all {
+		counts[c.IdentityID]++
+	}
+	return counts
 }
 
 func (m Model) handleCycleDomain() (tea.Model, tea.Cmd) {

--- a/internal/tui/tui_test.go
+++ b/internal/tui/tui_test.go
@@ -398,11 +398,32 @@ func TestListViewShowsIdentities(t *testing.T) {
 	m := newListModel(ids)
 	view := m.View()
 
-	if !strings.Contains(view, "abc12345") {
-		t.Error("should show identity ID")
+	if !strings.Contains(view, "Jane Doe") {
+		t.Error("should show name")
 	}
 	if !strings.Contains(view, "jane@zburn.id") {
 		t.Error("should show email")
+	}
+}
+
+func TestListViewCredentialCount(t *testing.T) {
+	ids := []identity.Identity{testIdentity()}
+	m := newListModel(ids)
+	m.credCounts = map[string]int{"abc12345": 3}
+	view := m.View()
+
+	if !strings.Contains(view, "(3)") {
+		t.Error("should show credential count badge")
+	}
+}
+
+func TestListViewCredentialCountZero(t *testing.T) {
+	ids := []identity.Identity{testIdentity()}
+	m := newListModel(ids)
+	view := m.View()
+
+	if strings.Contains(view, "(0)") {
+		t.Error("should not show (0) badge")
 	}
 }
 


### PR DESCRIPTION
Closes #80

Spec: zarlcorp/core/.manager/specs/121-redesign-identity-list.md

- Remove table header, ID column, and created date from list view
- Add credential count badge (N) after email when N > 0
- Bulk load credential counts in loadList() to avoid N+1 queries
- Add TestListViewCredentialCount and TestListViewCredentialCountZero tests