### PR TITLE
123: fix avatar rendering

### DIFF
--- a/internal/tui/generate.go
+++ b/internal/tui/generate.go
@@ -59,9 +59,10 @@ func renderAvatar() string {
 	}
 	var buf bytes.Buffer
 	opts := &kitty.Options{
-		Action: kitty.TransmitAndPut,
-		Format: kitty.PNG,
-		Chunk:  true,
+		Action:       kitty.TransmitAndPut,
+		Transmission: kitty.Direct,
+		Format:       kitty.PNG,
+		Chunk:        true,
 	}
 	if err := kitty.EncodeGraphics(&buf, img, opts); err != nil {
 		return ""

--- a/internal/tui/tui_test.go
+++ b/internal/tui/tui_test.go
@@ -858,6 +858,13 @@ func TestAvatarDataNotEmpty(t *testing.T) {
 	}
 }
 
+func TestRenderAvatarProducesPayload(t *testing.T) {
+	s := renderAvatar()
+	if len(s) < 100 {
+		t.Errorf("renderAvatar() returned %d bytes, want > 100 (got %q)", len(s), s)
+	}
+}
+
 // burn view tests
 
 func TestBurnConfirmViewShowsPlan(t *testing.T) {


### PR DESCRIPTION
Closes #84

Spec: zarlcorp/core/.manager/specs/123-fix-avatar-rendering.md

- Add missing Transmission: kitty.Direct to renderAvatar() options
- Without it, EncodeGraphics produced an empty payload (14 bytes instead of 419)
- Add TestRenderAvatarProducesPayload to verify escape sequence has image data